### PR TITLE
Fix download error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juzi/wechaty-puppet-service",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "description": "Puppet Service for Wechaty",
   "type": "module",
   "exports": {

--- a/src/file-box-helper/uuidify-file-box-grpc.ts
+++ b/src/file-box-helper/uuidify-file-box-grpc.ts
@@ -32,6 +32,10 @@ const uuidResolverGrpc: (grpcClient: () => pbPuppet.PuppetClient) => UuidLoader 
   const stream = response
     .pipe(chunkDecoder())
 
+  response.on('error', e => {
+    stream.emit('error', e)
+  })
+
   return stream
 }
 

--- a/src/server/puppet-implementation.ts
+++ b/src/server/puppet-implementation.ts
@@ -1749,12 +1749,17 @@ function puppetImplementation (
     download: async (call) => {
       log.verbose('PuppetServiceImpl', 'download()')
 
-      const uuid    = call.request.getId()
-      const fileBox = FileBoxUuid.fromUuid(uuid, { name: 'uuid.dat' })
+      try {
+        const uuid = call.request.getId()
+        const fileBox = FileBoxUuid.fromUuid(uuid, { name: 'uuid.dat' })
 
-      fileBox
-        .pipe(chunkEncoder(grpcPuppet.DownloadResponse))
-        .pipe(call as unknown as Writable)  // Huan(202203) FIXME: as unknown as
+        fileBox
+          .pipe(chunkEncoder(grpcPuppet.DownloadResponse))
+          .pipe(call as unknown as Writable)  // Huan(202203) FIXME: as unknown as
+      } catch (e) {
+        call.destroy(e as Error)
+      }
+
     },
 
     upload: async (call, callback) => {

--- a/src/server/puppet-server.ts
+++ b/src/server/puppet-server.ts
@@ -96,7 +96,9 @@ export class PuppetServer {
 
     if (!this.urnRegistry) {
       log.verbose('PuppetServer', 'start() initializing FileBox UUID URN Registry ...')
-      this.urnRegistry = new UniformResourceNameRegistry()
+      this.urnRegistry = new UniformResourceNameRegistry({
+        expireMilliseconds: 2 * 60 * 60 * 1000, // 2h
+      })
       await this.urnRegistry.init()
       log.verbose('PuppetServer', 'start() initializing FileBox UUID URN Registry ... done')
     }


### PR DESCRIPTION
https://juzibot.pingcode.com/pjm/items/632d58b75d501be2b178c429?
#WEC-475  修复获取群头像有时会出现unhandled exception的问题

先通过简单的延长过期时间，可以解决绝大部分（应该是全部）的问题。如果获取uuid的file-box失败，就destroy掉stream，避免卡死。这应该也能避免任何场景的uuid filebox下载出错卡死的情况。