### PR TITLE
feat(channel): map new ChannelPayload fields and mediaList in pb conv…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juzi/wechaty-puppet-service",
-  "version": "1.0.115",
+  "version": "1.0.116",
   "description": "Puppet Service for Wechaty",
   "type": "module",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@chatie/eslint-config": "^1.0.4",
     "@chatie/semver": "^0.4.7",
     "@chatie/tsconfig": "^4.6.3",
-    "@juzi/wechaty-puppet": "^1.0.138",
+    "@juzi/wechaty-puppet": "^1.0.139",
     "@juzi/wechaty-puppet-mock": "^1.0.1",
     "@swc/core": "1.3.39",
     "@types/google-protobuf": "^3.15.5",
@@ -70,10 +70,10 @@
     "why-is-node-running": "^2.2.1"
   },
   "peerDependencies": {
-    "@juzi/wechaty-puppet": "^1.0.138"
+    "@juzi/wechaty-puppet": "^1.0.139"
   },
   "dependencies": {
-    "@juzi/wechaty-grpc": "^1.0.102",
+    "@juzi/wechaty-grpc": "^1.0.103",
     "clone-class": "^1.1.1",
     "ducks": "^1.0.2",
     "file-box": "^1.5.5",

--- a/src/server/puppet-implementation.ts
+++ b/src/server/puppet-implementation.ts
@@ -43,7 +43,7 @@ import {
 import { log } from '../config.js'
 import { grpcError }          from './grpc-error.js'
 import { EventStreamManager } from './event-stream-manager.js'
-import { OptionalBooleanUnwrapper, OptionalBooleanWrapper, callRecordPayloadToPb, channelPayloadToPb, chatHistoryPayloadToPb, postPbToPayload, urlLinkPayloadToPb, channelCardPayloadToPb } from '../utils/pb-payload-helper.js'
+import { OptionalBooleanUnwrapper, OptionalBooleanWrapper, callRecordPayloadToPb, channelPayloadToPb, channelPbToPayload, chatHistoryPayloadToPb, postPbToPayload, urlLinkPayloadToPb, channelCardPayloadToPb } from '../utils/pb-payload-helper.js'
 import { grpcCallTypeToPuppetMedia, puppetCallMediaTypeToGrpc } from '../utils/call-media-mapping.js'
 import { TextContentType } from '@juzi/wechaty-puppet/types'
 
@@ -1503,14 +1503,12 @@ function puppetImplementation (
 
       try {
         const conversationId = call.request.getConversationId()
-        const pbChannelPayload = call.request.getChannel()?.toObject()
+        const pbChannel = call.request.getChannel()
 
-        if (!pbChannelPayload) {
-          return grpcError('messageSendUrl', new Error().stack, callback)
+        if (!pbChannel) {
+          return grpcError('messageSendChannel', new Error().stack, callback)
         }
-        const payload: PUPPET.payloads.Channel = {
-          ...pbChannelPayload,
-        }
+        const payload = channelPbToPayload(pbChannel)
 
         const messageId = await puppet.messageSendChannel(conversationId, payload)
 

--- a/src/utils/pb-payload-helper.ts
+++ b/src/utils/pb-payload-helper.ts
@@ -79,13 +79,33 @@ export const channelPayloadToPb = (grpcPuppet: grpcPuppet, channelPayload: PUPPE
   if (channelPayload.url) { pbChannelPayload.setUrl(channelPayload.url) }
   if (channelPayload.objectId) { pbChannelPayload.setObjectId(channelPayload.objectId) }
   if (channelPayload.objectNonceId) { pbChannelPayload.setObjectNonceId(channelPayload.objectNonceId) }
+  // 个微转发视频号所需补充字段
+  if (channelPayload.username) { pbChannelPayload.setUsername(channelPayload.username) }
+  if (channelPayload.authIconType) { pbChannelPayload.setAuthIconType(channelPayload.authIconType) }
+  if (channelPayload.authIconUrl) { pbChannelPayload.setAuthIconUrl(channelPayload.authIconUrl) }
+  if (channelPayload.fromUserName) { pbChannelPayload.setFromUserName(channelPayload.fromUserName) }
+  if (channelPayload.mediaList?.length) {
+    pbChannelPayload.setMediaListList(channelPayload.mediaList.map(media => {
+      const pbMedia = new grpcPuppet.ChannelMedia()
+      if (media.mediaType) { pbMedia.setMediaType(media.mediaType) }
+      if (media.url) { pbMedia.setUrl(media.url) }
+      if (media.thumbUrl) { pbMedia.setThumbUrl(media.thumbUrl) }
+      if (media.fullCoverUrl) { pbMedia.setFullCoverUrl(media.fullCoverUrl) }
+      if (media.coverUrl) { pbMedia.setCoverUrl(media.coverUrl) }
+      if (media.width) { pbMedia.setWidth(media.width) }
+      if (media.height) { pbMedia.setHeight(media.height) }
+      if (media.videoPlayDuration) { pbMedia.setVideoPlayDuration(media.videoPlayDuration) }
+      return pbMedia
+    }))
+  }
   return pbChannelPayload
 }
 
 export const channelPbToPayload = (channelPayloadPb: puppet.ChannelPayload) => {
-  const _channelPayloadPb = channelPayloadPb.toObject()
+  const { mediaListList, ..._channelPayloadPb } = channelPayloadPb.toObject()
   const channelPayload: PUPPET.payloads.Channel = {
     ..._channelPayloadPb,
+    mediaList: mediaListList,
   }
   return channelPayload
 }


### PR DESCRIPTION
…erters

为 puppet-phoenix（个微）转发视频号支持，扩展 ChannelPayload 的 pb<->payload 转换：

- channelPayloadToPb 增加 username/authIconType/authIconUrl/fromUserName 字段映射
- channelPayloadToPb 增加 mediaList 转换：构造 ChannelMedia 子消息并 setMediaListList
- channelPbToPayload 把 toObject() 输出的 mediaListList 字段重命名为 mediaList，匹配 puppet ChannelPayload 类型
- puppet-implementation.messageSendChannel 改用 channelPbToPayload，统一逻辑并修正既有 grpcError 标识('messageSendUrl' -> 'messageSendChannel')
- 依赖升级：@juzi/wechaty-puppet ^1.0.139, @juzi/wechaty-grpc ^1.0.103

字段在 pb 内全部为可选/repeated，对既有 puppet（如企微 puppet-workpro）向后兼容。