### PR TITLE
feat: bridge messageVoice / messageVoiceText over gRPC

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juzi/wechaty-puppet-service",
-  "version": "1.0.117",
+  "version": "1.0.118",
   "description": "Puppet Service for Wechaty",
   "type": "module",
   "exports": {
@@ -51,7 +51,7 @@
     "@chatie/eslint-config": "^1.0.4",
     "@chatie/semver": "^0.4.7",
     "@chatie/tsconfig": "^4.6.3",
-    "@juzi/wechaty-puppet": "^1.0.140",
+    "@juzi/wechaty-puppet": "^1.0.142",
     "@juzi/wechaty-puppet-mock": "^1.0.1",
     "@swc/core": "1.3.39",
     "@types/google-protobuf": "^3.15.5",
@@ -70,10 +70,10 @@
     "why-is-node-running": "^2.2.1"
   },
   "peerDependencies": {
-    "@juzi/wechaty-puppet": "^1.0.140"
+    "@juzi/wechaty-puppet": "^1.0.142"
   },
   "dependencies": {
-    "@juzi/wechaty-grpc": "^1.0.103",
+    "@juzi/wechaty-grpc": "^1.0.104",
     "clone-class": "^1.1.1",
     "ducks": "^1.0.2",
     "file-box": "^1.5.5",

--- a/src/client/puppet-service.ts
+++ b/src/client/puppet-service.ts
@@ -56,6 +56,7 @@ import { PayloadStore } from './payload-store.js'
 import { OptionalBooleanUnwrapper, OptionalBooleanWrapper, callRecordPbToPayload, channelPayloadToPb, channelPbToPayload, chatHistoryPbToPayload, contactPbToPayload, postPayloadToPb, roomMemberPbToPayload, urlLinkPbToPayload, channelCardPayloadToPb, channelCardPbToPayload, miniProgramPayloadToPb, urlLinkPayloadToPb, locationPayloadToPb } from '../utils/pb-payload-helper.js'
 import { puppetCallMediaTypeToGrpc, grpcCallTypeToPuppetMedia } from '../utils/call-media-mapping.js'
 import type { MessageBroadcastTargets } from '@juzi/wechaty-puppet/dist/esm/src/schemas/message.js'
+import type { VoiceTextPayload } from '@juzi/wechaty-puppet/dist/esm/src/schemas/voice.js'
 import { timeoutPromise } from 'gerror'
 import { BooleanIndicator } from 'state-switch'
 import type { Contact } from '@juzi/wechaty-puppet/types'
@@ -1529,6 +1530,40 @@ class PuppetService extends PUPPET.Puppet {
     }
 
     throw new Error(`failed to get filebox for message ${id}`)
+  }
+
+  override async messageVoice (id: string): Promise<FileBoxInterface> {
+    log.verbose('PuppetService', 'messageVoice(%s)', id)
+
+    const request = new grpcPuppet.MessageVoiceRequest()
+    request.setId(id)
+    const response = await util.promisify(
+      this.grpcManager.client.messageVoice
+        .bind(this.grpcManager.client),
+    )(request)
+
+    const jsonText = response.getFileBox()
+    if (jsonText) {
+      return this.FileBoxUuid.fromJSON(jsonText)
+    }
+
+    throw new Error(`failed to get voice filebox for message ${id}`)
+  }
+
+  override async messageVoiceText (id: string): Promise<VoiceTextPayload> {
+    log.verbose('PuppetService', 'messageVoiceText(%s)', id)
+
+    const request = new grpcPuppet.MessageVoiceTextRequest()
+    request.setId(id)
+    const response = await util.promisify(
+      this.grpcManager.client.messageVoiceText
+        .bind(this.grpcManager.client),
+    )(request)
+
+    return {
+      text     : response.getText(),
+      noSpeech : response.getNoSpeech(),
+    }
   }
 
   override async messagePreview (id: string): Promise<FileBoxInterface | undefined> {

--- a/src/server/puppet-implementation.ts
+++ b/src/server/puppet-implementation.ts
@@ -811,6 +811,44 @@ function puppetImplementation (
       }
     },
 
+    messageVoice: async (call, callback) => {
+      log.verbose('PuppetServiceImpl', 'messageVoice()')
+
+      try {
+        const id = call.request.getId()
+
+        const fileBox           = await puppet.messageVoice(id)
+        const serializedFileBox = await serializeFileBox(fileBox)
+
+        const response = new grpcPuppet.MessageVoiceResponse()
+        response.setFileBox(serializedFileBox)
+
+        return callback(null, response)
+
+      } catch (e) {
+        return grpcError('messageVoice', e, callback)
+      }
+    },
+
+    messageVoiceText: async (call, callback) => {
+      log.verbose('PuppetServiceImpl', 'messageVoiceText()')
+
+      try {
+        const id = call.request.getId()
+
+        const voiceText = await puppet.messageVoiceText(id)
+
+        const response = new grpcPuppet.MessageVoiceTextResponse()
+        response.setText(voiceText.text)
+        response.setNoSpeech(voiceText.noSpeech)
+
+        return callback(null, response)
+
+      } catch (e) {
+        return grpcError('messageVoiceText', e, callback)
+      }
+    },
+
     messageForward: async (call, callback) => {
       log.verbose('PuppetServiceImpl', 'messageForward()')
 


### PR DESCRIPTION
## What

Bridge the new voice second-request methods through the grpc client + server, symmetric to `messageImage` / `messageFile`:

- **client** (`src/client/puppet-service.ts`): `messageVoice` / `messageVoiceText` → new RPCs
- **server** (`src/server/puppet-implementation.ts`): handlers dispatch to `puppet.messageVoice` / `messageVoiceText`, standard `grpcError` fallback

## Why

Carries voice file + voice-to-text (ASR) as second requests. Errors propagate so the wechaty `Voice` sayable can fall back to `messageFile` + `payload.text` against older puppets.

## Deps / version

Requires the new interface + RPC: `@juzi/wechaty-grpc ^1.0.104`, `@juzi/wechaty-puppet ^1.0.142`. Version `1.0.117 → 1.0.118`.

Depends on juzibot/wechaty-puppet#97 and juzibot/wechaty-grpc#74. Part of: wechaty-puppet → wechaty-grpc → **wechaty-puppet-service** → wechaty → xiaoju-bot-nested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UCmXBqNF3QhpbLnQJTqgR2
