### PR TITLE
refactor: use public PUPPET.payloads.VoiceText (1.0.119)

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@chatie/eslint-config": "^1.0.4",
     "@chatie/semver": "^0.4.7",
     "@chatie/tsconfig": "^4.6.3",
-    "@juzi/wechaty-puppet": "^1.0.142",
+    "@juzi/wechaty-puppet": "^1.0.143",
     "@juzi/wechaty-puppet-mock": "^1.0.1",
     "@swc/core": "1.3.39",
     "@types/google-protobuf": "^3.15.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juzi/wechaty-puppet-service",
-  "version": "1.0.118",
+  "version": "1.0.119",
   "description": "Puppet Service for Wechaty",
   "type": "module",
   "exports": {
@@ -70,7 +70,7 @@
     "why-is-node-running": "^2.2.1"
   },
   "peerDependencies": {
-    "@juzi/wechaty-puppet": "^1.0.142"
+    "@juzi/wechaty-puppet": "^1.0.143"
   },
   "dependencies": {
     "@juzi/wechaty-grpc": "^1.0.104",

--- a/src/client/puppet-service.ts
+++ b/src/client/puppet-service.ts
@@ -56,7 +56,6 @@ import { PayloadStore } from './payload-store.js'
 import { OptionalBooleanUnwrapper, OptionalBooleanWrapper, callRecordPbToPayload, channelPayloadToPb, channelPbToPayload, chatHistoryPbToPayload, contactPbToPayload, postPayloadToPb, roomMemberPbToPayload, urlLinkPbToPayload, channelCardPayloadToPb, channelCardPbToPayload, miniProgramPayloadToPb, urlLinkPayloadToPb, locationPayloadToPb } from '../utils/pb-payload-helper.js'
 import { puppetCallMediaTypeToGrpc, grpcCallTypeToPuppetMedia } from '../utils/call-media-mapping.js'
 import type { MessageBroadcastTargets } from '@juzi/wechaty-puppet/dist/esm/src/schemas/message.js'
-import type { VoiceTextPayload } from '@juzi/wechaty-puppet/dist/esm/src/schemas/voice.js'
 import { timeoutPromise } from 'gerror'
 import { BooleanIndicator } from 'state-switch'
 import type { Contact } from '@juzi/wechaty-puppet/types'
@@ -1550,7 +1549,7 @@ class PuppetService extends PUPPET.Puppet {
     throw new Error(`failed to get voice filebox for message ${id}`)
   }
 
-  override async messageVoiceText (id: string): Promise<VoiceTextPayload> {
+  override async messageVoiceText (id: string): Promise<PUPPET.payloads.VoiceText> {
     log.verbose('PuppetService', 'messageVoiceText(%s)', id)
 
     const request = new grpcPuppet.MessageVoiceTextRequest()


### PR DESCRIPTION
> ⚠️ **DRAFT — blocked. Do not merge until the prerequisite below is satisfied.**

## Prerequisite (blocker)

Depends on **juzibot/wechaty-puppet#98** (`feat: re-export VoiceTextPayload via payloads barrel`) being **merged AND published to npm as `@juzi/wechaty-puppet@1.0.143`**.

`PUPPET.payloads.VoiceText` does not exist before 1.0.143, so this branch **will not typecheck / CI fails** until that publish lands and `npm install` resolves the bumped dep. Build was therefore **not** verified locally (installed dev deps are older).

**Unblock checklist:**
- [ ] puppet#98 merged
- [ ] `@juzi/wechaty-puppet@1.0.143` published
- [ ] `npm install` here (resolves `^1.0.143`)
- [ ] `npm run build` green → mark ready for review

## What

Replace the fragile deep import

```ts
import type { VoiceTextPayload } from '@juzi/wechaty-puppet/dist/esm/src/schemas/voice.js'
```

with the public barrel type `PUPPET.payloads.VoiceText` (`import * as PUPPET` already present).

## Changes

- `src/client/puppet-service.ts`: drop the deep import; `messageVoiceText(): Promise<PUPPET.payloads.VoiceText>`.
- `package.json`: `@juzi/wechaty-puppet` dep + peerDep `^1.0.142 → ^1.0.143`; version `1.0.118 → 1.0.119`.

## Note / out of scope

`line 58` still deep-imports `MessageBroadcastTargets` from `dist/esm/src/schemas/message.js` — same tech debt, left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)