### PR TITLE
feat: wire batchRoomPayload through client and server

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@chatie/eslint-config": "^1.0.4",
     "@chatie/semver": "^0.4.7",
     "@chatie/tsconfig": "^4.6.3",
-    "@juzi/wechaty-puppet": "^1.0.143",
+    "@juzi/wechaty-puppet": "^1.0.145",
     "@juzi/wechaty-puppet-mock": "^1.0.1",
     "@swc/core": "1.3.39",
     "@types/google-protobuf": "^3.15.5",
@@ -73,7 +73,7 @@
     "@juzi/wechaty-puppet": "^1.0.143"
   },
   "dependencies": {
-    "@juzi/wechaty-grpc": "^1.0.104",
+    "@juzi/wechaty-grpc": "^1.0.105",
     "clone-class": "^1.1.1",
     "ducks": "^1.0.2",
     "file-box": "^1.5.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juzi/wechaty-puppet-service",
-  "version": "1.0.120",
+  "version": "1.0.121",
   "description": "Puppet Service for Wechaty",
   "type": "module",
   "exports": {

--- a/src/client/puppet-service.ts
+++ b/src/client/puppet-service.ts
@@ -2278,6 +2278,64 @@ class PuppetService extends PUPPET.Puppet {
     return payload
   }
 
+  override async batchRoomRawPayload (roomIdList: string[]): Promise<Map<string, PUPPET.payloads.Room>> {
+    log.verbose('PuppetService', 'batchRoomRawPayload(%s)', roomIdList)
+
+    const result = new Map<string, PUPPET.payloads.Room>()
+    const roomIdSet = new Set<string>(roomIdList)
+    const needGetSet = new Set<string>()
+    for (const roomId of roomIdSet) {
+      const cachedRoomPayload = await this._payloadStore.room?.get(roomId)
+      if (cachedRoomPayload) {
+        result.set(roomId, cachedRoomPayload)
+      } else {
+        needGetSet.add(roomId)
+      }
+    }
+
+    if (needGetSet.size > 0) {
+      try {
+        const request = new grpcPuppet.BatchRoomPayloadRequest()
+        request.setIdsList(Array.from(needGetSet))
+
+        const response = await util.promisify(
+          this.grpcManager.client.batchRoomPayload
+            .bind(this.grpcManager.client),
+        )(request)
+
+        const payloads = response.getRoomPayloadsList()
+        for (const payload of payloads) {
+          const roomId = payload.getId()
+          const puppetPayload: PUPPET.payloads.Room = {
+            adminIdList   : payload.getAdminIdsList(),
+            avatar        : payload.getAvatar(),
+            handle        : payload.getHandle(),
+            id            : payload.getId(),
+            memberIdList  : payload.getMemberIdsList(),
+            ownerId       : payload.getOwnerId(),
+            topic         : payload.getTopic(),
+            additionalInfo: payload.getAdditionalInfo(),
+            remark        : payload.getRoomRemark(),
+            external      : payload.getExternal(),
+          }
+          const createTime = payload.getCreateTime()
+          if (createTime) {
+            puppetPayload.createTime = millisecondsFromTimestamp(createTime)
+          }
+          result.set(roomId, puppetPayload)
+          await this._payloadStore.room?.set(roomId, puppetPayload)
+        }
+      } catch (e) {
+        log.error('PuppetService', 'batchRoomRawPayload(%s, %s) error: %s, use one by one method', roomIdList, needGetSet, e)
+        for (const roomId of needGetSet) {
+          const payload = await this.roomRawPayload(roomId)
+          result.set(roomId, payload)
+        }
+      }
+    }
+    return result
+  }
+
   override async roomList (): Promise<string[]> {
     log.verbose('PuppetService', 'roomList()')
 

--- a/src/server/puppet-implementation.ts
+++ b/src/server/puppet-implementation.ts
@@ -2107,6 +2107,44 @@ function puppetImplementation (
       }
     },
 
+    batchRoomPayload: async (call, callback) => {
+      log.verbose('PuppetServiceImpl', 'batchRoomPayload()')
+
+      try {
+        const roomIdList = call.request.getIdsList()
+
+        const payloadMap = await puppet.batchRoomPayload(roomIdList)
+
+        const response = new grpcPuppet.BatchRoomPayloadResponse()
+
+        const payloads: grpcPuppet.RoomPayloadResponse[] = []
+        for (const [ _, payload ] of payloadMap.entries()) {
+          const pb = new grpcPuppet.RoomPayloadResponse()
+          pb.setAdminIdsList(payload.adminIdList)
+          pb.setAvatar(payload.avatar || '')
+          pb.setHandle(payload.handle || '')
+          pb.setId(payload.id)
+          pb.setMemberIdsList(payload.memberIdList)
+          pb.setOwnerId(payload.ownerId || '')
+          pb.setTopic(payload.topic)
+          pb.setAdditionalInfo(payload.additionalInfo || '')
+          pb.setRoomRemark(payload.remark || '')
+          pb.setExternal(!!payload.external)
+          if (payload.createTime) {
+            pb.setCreateTime(timestampFromMilliseconds(payload.createTime))
+          }
+          payloads.push(pb)
+        }
+
+        response.setRoomPayloadsList(payloads)
+
+        return callback(null, response)
+
+      } catch (e) {
+        return grpcError('batchRoomPayload', e, callback)
+      }
+    },
+
     roomQRCode: async (call, callback) => {
       log.verbose('PuppetServiceImpl', 'roomQRCode()')
 


### PR DESCRIPTION
## Summary

- Client (`src/client/puppet-service.ts`): new `batchRoomRawPayload` override mirroring `batchContactRawPayload` — PayloadStore cache lookup → batched `BatchRoomPayload` gRPC call → per-id fallback on error
- Server (`src/server/puppet-implementation.ts`): new `batchRoomPayload` handler routes to `puppet.batchRoomPayload`, serializes the returned Map to `RoomPayloadResponse[]`
- Bumps `@juzi/wechaty-grpc` to `^1.0.105` and `@juzi/wechaty-puppet` to `^1.0.145`

## Why

3rd of 4 coordinated PRs for batched room payload fetching (backing `findAllIter` in wechaty):

- [x] wechaty-grpc#76 — `BatchRoomPayload` RPC (merged, `@juzi/wechaty-grpc@1.0.105`)
- [x] wechaty-puppet#100 — `batchRoomPayload` mixin (merged, `@juzi/wechaty-puppet@1.0.145`)
- [x] **wechaty-puppet-service** — this PR
- [ ] wechaty — adds `Contact.findAllIter` / `Room.findAllIter`

## Test plan

- [x] `npm run lint` — pass
- [x] `npm test` (24 spec) — pass with local linked upstream packages
- [ ] CI installs `@juzi/wechaty-grpc@1.0.105` + `@juzi/wechaty-puppet@1.0.145` from npm