### PR TITLE
feat: add callId mapping in pb-payload-helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juzi/wechaty-puppet-service",
-  "version": "1.0.121",
+  "version": "1.0.122",
   "description": "Puppet Service for Wechaty",
   "type": "module",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@chatie/eslint-config": "^1.0.4",
     "@chatie/semver": "^0.4.7",
     "@chatie/tsconfig": "^4.6.3",
-    "@juzi/wechaty-puppet": "^1.0.145",
+    "@juzi/wechaty-puppet": "^1.0.146",
     "@juzi/wechaty-puppet-mock": "^1.0.1",
     "@swc/core": "1.3.39",
     "@types/google-protobuf": "^3.15.5",
@@ -73,7 +73,7 @@
     "@juzi/wechaty-puppet": "^1.0.143"
   },
   "dependencies": {
-    "@juzi/wechaty-grpc": "^1.0.105",
+    "@juzi/wechaty-grpc": "^1.0.106",
     "clone-class": "^1.1.1",
     "ducks": "^1.0.2",
     "file-box": "^1.5.5",

--- a/src/utils/pb-payload-helper.ts
+++ b/src/utils/pb-payload-helper.ts
@@ -284,6 +284,8 @@ export const callRecordPbToPayload = (callRecordPb: puppet.CallRecordPayload) =>
     type: callRecordPb.getType(),
     status: callRecordPb.getStatus(),
   }
+  const callId = callRecordPb.getCallId()
+  if (callId) { callRecordPayload.callId = callId }
   return callRecordPayload
 }
 
@@ -294,6 +296,7 @@ export const callRecordPayloadToPb = (grpcPuppet: grpcPuppet, callRecordPayload:
   pbCallRecordPayload.setLength(callRecordPayload.length)
   pbCallRecordPayload.setType(callRecordPayload.type)
   pbCallRecordPayload.setStatus(callRecordPayload.status)
+  if (callRecordPayload.callId) { pbCallRecordPayload.setCallId(callRecordPayload.callId) }
 
   return pbCallRecordPayload
 }


### PR DESCRIPTION
## Summary

- `pb-payload-helper`: `callRecordPbToPayload` / `callRecordPayloadToPb` 双向加 `callId` 映射，空串视为 `undefined`，与 puppet schema 中可选字段语义对齐。
- 配套依赖升级：`@juzi/wechaty-grpc` → `^1.0.106`（proto 新增 `call_id` 字段），`@juzi/wechaty-puppet` (devDep) → `^1.0.146`（`CallRecordPayload.callId` schema）。
- 发版：`1.0.122`。

## Test plan

- [x] `npm run lint`
- [x] `npm test`（tap 全绿）