### PR TITLE
feat/dirty-hardening-round2: await fastDirty before emit, precise RoomMember dirty

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juzi/wechaty-puppet-service",
-  "version": "1.0.122",
+  "version": "1.0.123",
   "description": "Puppet Service for Wechaty",
   "type": "module",
   "exports": {

--- a/src/client/puppet-service.ts
+++ b/src/client/puppet-service.ts
@@ -559,7 +559,7 @@ class PuppetService extends PUPPET.Puppet {
             await previous
           } catch (_) { /* ignore, upstream already reported */ }
           const current = await store.get(roomId)
-          if (!current || !(memberId in current)) {
+          if (!current || !Object.prototype.hasOwnProperty.call(current, memberId)) {
             return
           }
           const { [memberId]: _drop, ...rest } = current

--- a/src/client/puppet-service.ts
+++ b/src/client/puppet-service.ts
@@ -517,9 +517,29 @@ class PuppetService extends PUPPET.Puppet {
       [PUPPET.types.Dirty.Post]:         async (_: string) => {},
       [PUPPET.types.Dirty.Room]:         async (id: string) => this._payloadStore.room?.delete(id),
       [PUPPET.types.Dirty.RoomMember]:   async (id: string) => {
-        const [ roomId ] = id.split(PUPPET.STRING_SPLITTER)
-        if (roomId) {
-          await this._payloadStore.roomMember?.delete(roomId)
+        const [ roomId, memberId ] = id.split(PUPPET.STRING_SPLITTER)
+        if (!roomId) {
+          return
+        }
+        const store = this._payloadStore.roomMember
+        if (!store) {
+          return
+        }
+        // Bare roomId: the whole member set is stale, drop the row.
+        if (memberId === undefined) {
+          await store.delete(roomId)
+          return
+        }
+        // Compound id: drop only the named member and keep siblings hot.
+        const current = await store.get(roomId)
+        if (!current || !(memberId in current)) {
+          return
+        }
+        const { [memberId]: _drop, ...rest } = current
+        if (Object.keys(rest).length === 0) {
+          await store.delete(roomId)
+        } else {
+          await store.set(roomId, rest)
         }
       },
       [PUPPET.types.Dirty.Tag]:          async (id: string) => this._payloadStore.tag?.delete(id),

--- a/src/client/puppet-service.ts
+++ b/src/client/puppet-service.ts
@@ -110,6 +110,21 @@ class PuppetService extends PUPPET.Puppet {
 
   protected _payloadStore: PayloadStore
 
+  /**
+   * Per-roomId serialization chain for RoomMember compound dirty events.
+   *
+   * The compound RoomMember handler is a `get → mutate → set` sequence
+   * across an async FlashStore. Two dirty events for the same roomId
+   * (e.g. member-A and member-B, arriving back-to-back) would otherwise
+   * both read the same snapshot and each write back with only their own
+   * key removed -- losing one of the deletes.
+   *
+   * Keyed by roomId, each entry chains the pending handler run so a
+   * follow-up dirty for the same room waits for the in-flight one to
+   * finish. Entries self-clean after their tail resolves.
+   */
+  private _roomMemberDirtyChain: Map<string, Promise<void>> = new Map()
+
   private timeoutMilliseconds: number
 
   protected _grpcManager?: GrpcManager
@@ -526,20 +541,43 @@ class PuppetService extends PUPPET.Puppet {
           return
         }
         // Bare roomId: the whole member set is stale, drop the row.
+        // Row-level delete is idempotent so it does not need serialization.
         if (memberId === undefined) {
           await store.delete(roomId)
           return
         }
-        // Compound id: drop only the named member and keep siblings hot.
-        const current = await store.get(roomId)
-        if (!current || !(memberId in current)) {
-          return
-        }
-        const { [memberId]: _drop, ...rest } = current
-        if (Object.keys(rest).length === 0) {
-          await store.delete(roomId)
-        } else {
-          await store.set(roomId, rest)
+        // Compound id: `get → mutate → set` is a read-modify-write across
+        // an async store. Serialize per roomId so two concurrent compound
+        // dirties don't each read the same snapshot and each drop only
+        // their own key -- which would lose one of the two deletes.
+        const previous = this._roomMemberDirtyChain.get(roomId) ?? Promise.resolve()
+        const next = (async () => {
+          // Swallow the previous link's rejection so a failure upstream
+          // does not silently skip our own mutation. The prior handler
+          // already reported its error via fastDirty()'s try/catch.
+          try {
+            await previous
+          } catch (_) { /* ignore, upstream already reported */ }
+          const current = await store.get(roomId)
+          if (!current || !(memberId in current)) {
+            return
+          }
+          const { [memberId]: _drop, ...rest } = current
+          if (Object.keys(rest).length === 0) {
+            await store.delete(roomId)
+          } else {
+            await store.set(roomId, rest)
+          }
+        })()
+        this._roomMemberDirtyChain.set(roomId, next)
+        try {
+          await next
+        } finally {
+          // Only clear the slot if we are still the tail; otherwise a
+          // later handler has already extended the chain and owns cleanup.
+          if (this._roomMemberDirtyChain.get(roomId) === next) {
+            this._roomMemberDirtyChain.delete(roomId)
+          }
         }
       },
       [PUPPET.types.Dirty.Tag]:          async (id: string) => this._payloadStore.tag?.delete(id),

--- a/tests/fast-dirty-room-member.spec.ts
+++ b/tests/fast-dirty-room-member.spec.ts
@@ -128,3 +128,39 @@ test('fastDirty(RoomMember) on unknown member is a no-op', async t => {
 
   await cleanup(puppet, token)
 })
+
+test('fastDirty(RoomMember) concurrent compound dirties on same roomId drop every named member', async t => {
+  const { puppet, token } = await makePuppet()
+
+  const roomId = 'room-test-id-race'
+  await puppet._payloadStore.roomMember.set(roomId, {
+    'member-A': { id: 'member-A', name: 'A' } as any,
+    'member-B': { id: 'member-B', name: 'B' } as any,
+  })
+
+  // Fire both compound dirties without awaiting between them so their
+  // `get → mutate → set` cycles interleave. Without per-roomId
+  // serialization, both reads would see {A, B}, both writes would keep
+  // one sibling, and one of the two deletes would be lost.
+  await Promise.all([
+    puppet.fastDirty({
+      payloadType: PUPPET.types.Dirty.RoomMember,
+      payloadId  : `${roomId}${PUPPET.STRING_SPLITTER}member-A`,
+    }),
+    puppet.fastDirty({
+      payloadType: PUPPET.types.Dirty.RoomMember,
+      payloadId  : `${roomId}${PUPPET.STRING_SPLITTER}member-B`,
+    }),
+  ])
+
+  const after = await puppet._payloadStore.roomMember.get(roomId)
+  // Either the whole row is gone (last shrink deleted it) or the record
+  // is empty. Both are acceptable "no members left" observations.
+  const noMembersLeft = !after || Object.keys(after).length === 0
+  t.ok(
+    noMembersLeft,
+    `both dirtied members must be evicted, got: ${JSON.stringify(after)}`,
+  )
+
+  await cleanup(puppet, token)
+})

--- a/tests/fast-dirty-room-member.spec.ts
+++ b/tests/fast-dirty-room-member.spec.ts
@@ -1,19 +1,24 @@
 #!/usr/bin/env -S node --no-warnings --loader ts-node/esm
 /**
- * Regression test for the RoomMember persistent-store dirty bug.
+ * Regression tests for the RoomMember persistent-store dirty semantics.
  *
- * The puppet-side cache mixin already knows that RoomMember dirty ids are
- * sometimes a compound `"<roomId><memberId>"` (using STRING_SPLITTER)
- * and splits the id before deleting from the in-memory LRU
- * (wechaty-puppet/src/mixins/cache-mixin.ts).
+ * The persistent `PayloadStore.roomMember` is a
+ * `FlashStore<roomId, {[memberId]: RoomMember}>` -- a per-room record of
+ * members. Dirty ids arrive in two shapes:
  *
- * However the client-side `fastDirty` here passes the raw id straight to
- * `PayloadStore.roomMember.delete`. The persistent FlashStore is keyed by
- * roomId only, so the delete silently no-ops and the stale entry survives
- * across process restarts.
+ *   1. A compound `"<roomId><STRING_SPLITTER><memberId>"` -- a single
+ *      member's payload went stale (e.g. one member renamed).
+ *   2. A bare `"<roomId>"` -- the whole room's member set went stale.
  *
- * This test populates the store, fires the dirty path with a compound id,
- * and asserts the entry is gone.
+ * The previous handler treated both shapes the same by calling
+ * `roomMember.delete(roomId)`, which threw away the entire room's
+ * cache even when only one member was dirty. That thrash forces the
+ * next N-1 members to re-fetch over gRPC.
+ *
+ * The new handler must:
+ *   - On compound id: drop only the named member, keep the rest.
+ *   - On compound id whose split leaves the record empty: delete the row.
+ *   - On bare roomId: delete the entire row (as before).
  */
 import { test } from 'tstest'
 import os from 'os'
@@ -24,12 +29,26 @@ import * as PUPPET from '@juzi/wechaty-puppet'
 
 import { PuppetService } from '../src/mod.js'
 
-test('fastDirty(RoomMember, "<roomId>\\u001F<memberId>") must clear the room entry', async t => {
+const makePuppet = async () => {
   const token = `puppet_service_test_${Date.now()}_${Math.floor(Math.random() * 1e6)}`
   const puppet = new PuppetService({ token }) as any
-
   const accountId = 'acct-test'
   await puppet._payloadStore.start(accountId)
+  return { puppet, token }
+}
+
+const cleanup = async (puppet: any, token: string) => {
+  await puppet._payloadStore.stop()
+  try {
+    await fs.promises.rm(
+      path.join(os.homedir(), '.wechaty', 'wechaty-puppet-service', token),
+      { recursive: true, force: true },
+    )
+  } catch (_) { /* ignore */ }
+}
+
+test('fastDirty(RoomMember, "<roomId>\\u001F<memberId>") drops only the named member', async t => {
+  const { puppet, token } = await makePuppet()
 
   const roomId = 'room-test-id'
   await puppet._payloadStore.roomMember.set(roomId, {
@@ -37,24 +56,75 @@ test('fastDirty(RoomMember, "<roomId>\\u001F<memberId>") must clear the room ent
     'member-B': { id: 'member-B', name: 'B' } as any,
   })
 
-  const before = await puppet._payloadStore.roomMember.get(roomId)
-  t.ok(before, 'sanity: roomMember entry exists before dirty')
-
   await puppet.fastDirty({
     payloadType: PUPPET.types.Dirty.RoomMember,
     payloadId  : `${roomId}${PUPPET.STRING_SPLITTER}member-A`,
   })
 
   const after = await puppet._payloadStore.roomMember.get(roomId)
-  t.notOk(after, 'roomMember entry must be cleared after compound-id dirty')
+  t.ok(after, 'room entry must survive when only one member is dirtied')
+  t.notOk(after && after['member-A'], 'dirtied member-A must be gone')
+  t.ok(after && after['member-B'], 'unrelated member-B must be preserved')
 
-  await puppet._payloadStore.stop()
+  await cleanup(puppet, token)
+})
 
-  // best-effort cleanup of the on-disk store dir
-  try {
-    await fs.promises.rm(
-      path.join(os.homedir(), '.wechaty', 'wechaty-puppet-service', token),
-      { recursive: true, force: true },
-    )
-  } catch (_) { /* ignore */ }
+test('fastDirty(RoomMember, "<roomId>\\u001F<lastMember>") deletes the row when empty', async t => {
+  const { puppet, token } = await makePuppet()
+
+  const roomId = 'room-test-id-lone'
+  await puppet._payloadStore.roomMember.set(roomId, {
+    'only-member': { id: 'only-member', name: 'Solo' } as any,
+  })
+
+  await puppet.fastDirty({
+    payloadType: PUPPET.types.Dirty.RoomMember,
+    payloadId  : `${roomId}${PUPPET.STRING_SPLITTER}only-member`,
+  })
+
+  const after = await puppet._payloadStore.roomMember.get(roomId)
+  t.notOk(after, 'row must be deleted once the record has no members left')
+
+  await cleanup(puppet, token)
+})
+
+test('fastDirty(RoomMember, "<roomId>") clears the whole room entry', async t => {
+  const { puppet, token } = await makePuppet()
+
+  const roomId = 'room-test-id-full'
+  await puppet._payloadStore.roomMember.set(roomId, {
+    'member-A': { id: 'member-A', name: 'A' } as any,
+    'member-B': { id: 'member-B', name: 'B' } as any,
+  })
+
+  await puppet.fastDirty({
+    payloadType: PUPPET.types.Dirty.RoomMember,
+    payloadId  : roomId,
+  })
+
+  const after = await puppet._payloadStore.roomMember.get(roomId)
+  t.notOk(after, 'bare roomId dirty must clear the whole row')
+
+  await cleanup(puppet, token)
+})
+
+test('fastDirty(RoomMember) on unknown member is a no-op', async t => {
+  const { puppet, token } = await makePuppet()
+
+  const roomId = 'room-test-id-noop'
+  const before = {
+    'member-A': { id: 'member-A', name: 'A' } as any,
+    'member-B': { id: 'member-B', name: 'B' } as any,
+  }
+  await puppet._payloadStore.roomMember.set(roomId, before)
+
+  await puppet.fastDirty({
+    payloadType: PUPPET.types.Dirty.RoomMember,
+    payloadId  : `${roomId}${PUPPET.STRING_SPLITTER}ghost-member`,
+  })
+
+  const after = await puppet._payloadStore.roomMember.get(roomId)
+  t.same(after, before, 'unrelated dirty must not disturb the record')
+
+  await cleanup(puppet, token)
 })

--- a/tests/fast-dirty-room-member.spec.ts
+++ b/tests/fast-dirty-room-member.spec.ts
@@ -164,3 +164,26 @@ test('fastDirty(RoomMember) concurrent compound dirties on same roomId drop ever
 
   await cleanup(puppet, token)
 })
+
+test('fastDirty(RoomMember) prototype-key member id must not match a real member', async t => {
+  const { puppet, token } = await makePuppet()
+
+  const roomId = 'room-test-id-proto'
+  const before = {
+    'member-A': { id: 'member-A', name: 'A' } as any,
+  }
+  await puppet._payloadStore.roomMember.set(roomId, before)
+
+  // `toString` exists on Object.prototype; a naive `memberId in current`
+  // check would match it and take the mutate branch. The correct guard
+  // uses hasOwnProperty and treats this as an unknown member.
+  await puppet.fastDirty({
+    payloadType: PUPPET.types.Dirty.RoomMember,
+    payloadId  : `${roomId}${PUPPET.STRING_SPLITTER}toString`,
+  })
+
+  const after = await puppet._payloadStore.roomMember.get(roomId)
+  t.same(after, before, 'prototype-key dirty must be a no-op')
+
+  await cleanup(puppet, token)
+})

--- a/tests/grpc-stream-dirty-order.spec.ts
+++ b/tests/grpc-stream-dirty-order.spec.ts
@@ -1,0 +1,70 @@
+#!/usr/bin/env -S node --no-warnings --loader ts-node/esm
+/**
+ * Regression / hardening test for the EVENT_TYPE_DIRTY dispatch order.
+ *
+ * Client-side dirty handling touches two independent caches:
+ *
+ *   - `fastDirty()` clears `_payloadStore` (FlashStore, on disk, async).
+ *   - `emit('dirty')` triggers the puppet-side CacheMixin which clears
+ *     the in-memory LRU synchronously in the same tick.
+ *
+ * If `emit('dirty')` runs before `fastDirty()` resolves, a listener that
+ * immediately reads back the payload -- as CacheMixin.onDirty does when
+ * a caller races with the dirty event -- can:
+ *
+ *   1. See an LRU miss (already cleared),
+ *   2. Refetch via `contactRawPayload` etc.,
+ *   3. Hit the still-un-cleared `_payloadStore` entry,
+ *   4. Repopulate the LRU with the stale row that fastDirty is about
+ *      to delete a microtask later,
+ *   5. And the fresh fastDirty delete no-ops against a now-cold key.
+ *
+ * The current implementation `await`s fastDirty before emitting. This
+ * test pins that invariant: fastDirty must fully resolve before any
+ * `dirty` listener observes the event.
+ */
+import { test } from 'tstest'
+
+import * as PUPPET from '@juzi/wechaty-puppet'
+import { puppet as grpcPuppet } from '@juzi/wechaty-grpc'
+
+import { PuppetService } from '../src/mod.js'
+
+test('onGrpcStreamEvent awaits fastDirty before emitting dirty', async t => {
+  const token = `puppet_service_test_${Date.now()}_${Math.floor(Math.random() * 1e6)}`
+  const puppet = new PuppetService({ token }) as any
+
+  let fastDirtyResolvedAt: number | undefined
+  let dirtyEmittedAt: number | undefined
+
+  const FASTDIRTY_DELAY_MS = 50
+
+  puppet.fastDirty = async (_payload: PUPPET.payloads.EventDirty) => {
+    await new Promise(resolve => setTimeout(resolve, FASTDIRTY_DELAY_MS))
+    fastDirtyResolvedAt = Date.now()
+  }
+
+  puppet.on('dirty', () => {
+    dirtyEmittedAt = Date.now()
+  })
+
+  const dirtyJson = JSON.stringify({
+    payloadType: PUPPET.types.Dirty.Contact,
+    payloadId  : 'contact-x',
+  })
+
+  const fakeEvent = {
+    getType   : () => grpcPuppet.EventType.EVENT_TYPE_DIRTY,
+    getPayload: () => dirtyJson,
+    getSeq    : () => 0,
+  }
+
+  await puppet.onGrpcStreamEvent(fakeEvent)
+
+  t.ok(fastDirtyResolvedAt, 'fastDirty must have been invoked')
+  t.ok(dirtyEmittedAt, 'dirty listener must have been invoked')
+  t.ok(
+    fastDirtyResolvedAt! <= dirtyEmittedAt!,
+    `dirty emit (${dirtyEmittedAt}) must not precede fastDirty resolve (${fastDirtyResolvedAt})`,
+  )
+})

--- a/tests/grpc-stream-dirty-order.spec.ts
+++ b/tests/grpc-stream-dirty-order.spec.ts
@@ -23,7 +23,7 @@
  * test pins that invariant: fastDirty must fully resolve before any
  * `dirty` listener observes the event.
  */
-import { test } from 'tstest'
+import { test, sinon } from 'tstest'
 
 import * as PUPPET from '@juzi/wechaty-puppet'
 import { puppet as grpcPuppet } from '@juzi/wechaty-grpc'
@@ -67,4 +67,72 @@ test('onGrpcStreamEvent awaits fastDirty before emitting dirty', async t => {
     fastDirtyResolvedAt! <= dirtyEmittedAt!,
     `dirty emit (${dirtyEmittedAt}) must not precede fastDirty resolve (${fastDirtyResolvedAt})`,
   )
+})
+
+test('onGrpcStreamEvent: dirty emit sequence-number is strictly after every fastDirty resolution', async t => {
+  // Wall-clock ordering (the baseline test above) is fine as a smoke
+  // signal but can collapse to a tie when both boundaries fall inside
+  // the same millisecond. The invariant we actually care about is
+  // *causal*: each fastDirty must have fully resolved before the
+  // corresponding dirty emit fires. Record call ordinals from a shared
+  // monotonic counter to pin that -- ordinals cannot tie.
+  const token = `puppet_service_test_${Date.now()}_${Math.floor(Math.random() * 1e6)}`
+  const puppet = new PuppetService({ token }) as any
+
+  let sequence = 0
+  const nextOrdinal = () => ++sequence
+
+  // Order of interest per event: fastDirty enter -> fastDirty resolve -> dirty emit.
+  const fastDirtyEnterOrdinals: number[] = []
+  const fastDirtyResolveOrdinals: number[] = []
+  const dirtyEmitOrdinals: number[] = []
+
+  const fastDirtyStub = sinon.stub().callsFake(async (_payload: PUPPET.payloads.EventDirty) => {
+    fastDirtyEnterOrdinals.push(nextOrdinal())
+    // Yield the microtask queue so a broken ordering would surface: if
+    // emit ran ahead of the await point below, its ordinal would slot
+    // between our enter and resolve records.
+    await new Promise(resolve => setImmediate(resolve))
+    fastDirtyResolveOrdinals.push(nextOrdinal())
+  })
+  puppet.fastDirty = fastDirtyStub
+
+  const dirtySpy = sinon.spy(() => {
+    dirtyEmitOrdinals.push(nextOrdinal())
+  })
+  puppet.on('dirty', dirtySpy)
+
+  const makeEvent = (payloadId: string) => {
+    const dirtyJson = JSON.stringify({
+      payloadType: PUPPET.types.Dirty.Contact,
+      payloadId,
+    })
+    return {
+      getType   : () => grpcPuppet.EventType.EVENT_TYPE_DIRTY,
+      getPayload: () => dirtyJson,
+      getSeq    : () => 0,
+    }
+  }
+
+  // Two back-to-back dirty events: this is the scenario Fix #6 pins,
+  // sequential await must hold across both.
+  await puppet.onGrpcStreamEvent(makeEvent('contact-1'))
+  await puppet.onGrpcStreamEvent(makeEvent('contact-2'))
+
+  t.equal(fastDirtyStub.callCount, 2, 'fastDirty invoked once per dirty event')
+  t.equal(dirtySpy.callCount, 2, 'dirty listener invoked once per dirty event')
+  t.equal(fastDirtyEnterOrdinals.length, 2, 'both fastDirty invocations recorded an entry ordinal')
+  t.equal(fastDirtyResolveOrdinals.length, 2, 'both fastDirty invocations recorded a resolve ordinal')
+  t.equal(dirtyEmitOrdinals.length, 2, 'both dirty emits recorded an ordinal')
+
+  for (let i = 0; i < 2; i++) {
+    t.ok(
+      fastDirtyEnterOrdinals[i]! < fastDirtyResolveOrdinals[i]!,
+      `event #${i}: fastDirty must enter (ord=${fastDirtyEnterOrdinals[i]}) before it resolves (ord=${fastDirtyResolveOrdinals[i]})`,
+    )
+    t.ok(
+      fastDirtyResolveOrdinals[i]! < dirtyEmitOrdinals[i]!,
+      `event #${i}: dirty emit ordinal (${dirtyEmitOrdinals[i]}) must strictly follow fastDirty resolve ordinal (${fastDirtyResolveOrdinals[i]})`,
+    )
+  }
 })


### PR DESCRIPTION
## Summary

Round-2 hardening on the client dirty path, follow-up to #94.

### #6 — pin `await fastDirty()` → `emit('dirty')` order

The ordering was already established by #94 (`await this.fastDirty(dirtyPayload); this.emit('dirty', dirtyPayload)`) and this round does not touch the dispatch code. It adds a regression/hardening test that pins the invariant so a future refactor cannot silently parallelize the two:

- `fastDirty` clears the async `_payloadStore` FlashStore row.
- `emit('dirty')` synchronously drives CacheMixin.onDirty which clears the in-memory LRU.

If a listener races between the two, it can refetch from the still-warm `_payloadStore` and repopulate the LRU with the very row `fastDirty` was about to purge. The new test uses a slow-`fastDirty` stub plus a timestamp probe on the `dirty` listener; verified locally that swapping `await` → `void` on the dispatch flips it red.

### #9 — precise RoomMember dirty in `_payloadStore`

`PayloadStore.roomMember` is `FlashStore<roomId, Record<memberId, RoomMember>>`. The compound RoomMember dirty id `"<roomId><STRING_SPLITTER><memberId>"` signals that a single member's payload went stale (e.g. one nickname changed). The previous handler split the id but still called `roomMember.delete(roomId)`, throwing away N-1 unrelated members and forcing them to re-fetch over gRPC on the next read.

New behavior:
- bare `<roomId>` (memberId `undefined`): delete the row (as before).
- compound id, member present: rebuild the record without that key; delete the row if it becomes empty.
- compound id, member absent: no-op.

This mirrors the member-level LRU eviction the puppet-side cache mixin already does, so the persistent and in-memory tiers stay in sync.

Companion PR: juzibot/wechaty-puppet `feat/cache-hardening-round2`.

## Test plan

- [x] `npm run lint` (es + ts + md all clean)
- [x] `npm test` (25/25 suites pass, including the two new specs)
- [ ] Integration: `npm link` with the sibling wechaty-puppet round-2 fix, trigger a single member nickname change on a live bot, confirm other members in the same room stay cache-HIT in both LRU and FlashStore.