### PR TITLE
feat: adopt pluggable per-instance logger from wechaty-puppet

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juzi/wechaty-puppet-service",
-  "version": "1.0.121",
+  "version": "1.0.122",
   "description": "Puppet Service for Wechaty",
   "type": "module",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juzi/wechaty-puppet-service",
-  "version": "1.0.123",
+  "version": "1.0.124",
   "description": "Puppet Service for Wechaty",
   "type": "module",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@swc/core": "1.3.39",
     "@types/google-protobuf": "^3.15.5",
     "@types/lru-cache": "^7.5.0",
+    "@types/node": "^20",
     "@types/semver": "^7.3.9",
     "@types/temp": "^0.9.1",
     "@types/uuid": "^8.3.4",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@chatie/eslint-config": "^1.0.4",
     "@chatie/semver": "^0.4.7",
     "@chatie/tsconfig": "^4.6.3",
-    "@juzi/wechaty-puppet": "^1.0.146",
+    "@juzi/wechaty-puppet": "^1.0.147",
     "@juzi/wechaty-puppet-mock": "^1.0.1",
     "@swc/core": "1.3.39",
     "@types/google-protobuf": "^3.15.5",
@@ -70,7 +70,7 @@
     "why-is-node-running": "^2.2.1"
   },
   "peerDependencies": {
-    "@juzi/wechaty-puppet": "^1.0.143"
+    "@juzi/wechaty-puppet": "^1.0.147"
   },
   "dependencies": {
     "@juzi/wechaty-grpc": "^1.0.106",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juzi/wechaty-puppet-service",
-  "version": "1.0.122",
+  "version": "1.0.123",
   "description": "Puppet Service for Wechaty",
   "type": "module",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@chatie/eslint-config": "^1.0.4",
     "@chatie/semver": "^0.4.7",
     "@chatie/tsconfig": "^4.6.3",
-    "@juzi/wechaty-puppet": "^1.0.147",
+    "@juzi/wechaty-puppet": "^1.0.148",
     "@juzi/wechaty-puppet-mock": "^1.0.1",
     "@swc/core": "1.3.39",
     "@types/google-protobuf": "^3.15.5",
@@ -70,7 +70,7 @@
     "why-is-node-running": "^2.2.1"
   },
   "peerDependencies": {
-    "@juzi/wechaty-puppet": "^1.0.147"
+    "@juzi/wechaty-puppet": "^1.0.148"
   },
   "dependencies": {
     "@juzi/wechaty-grpc": "^1.0.106",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@chatie/eslint-config": "^1.0.4",
     "@chatie/semver": "^0.4.7",
     "@chatie/tsconfig": "^4.6.3",
-    "@juzi/wechaty-puppet": "^1.0.145",
+    "@juzi/wechaty-puppet": "^1.0.146",
     "@juzi/wechaty-puppet-mock": "^1.0.1",
     "@swc/core": "1.3.39",
     "@types/google-protobuf": "^3.15.5",
@@ -73,7 +73,7 @@
     "@juzi/wechaty-puppet": "^1.0.143"
   },
   "dependencies": {
-    "@juzi/wechaty-grpc": "^1.0.105",
+    "@juzi/wechaty-grpc": "^1.0.106",
     "clone-class": "^1.1.1",
     "ducks": "^1.0.2",
     "file-box": "^1.5.5",

--- a/src/client/grpc-manager.ts
+++ b/src/client/grpc-manager.ts
@@ -21,8 +21,10 @@ import util from 'util'
 import EventEmitter from 'events'
 import crypto from 'crypto'
 
-import { log } from '@juzi/wechaty-puppet'
-import type { LoggerLike } from '@juzi/wechaty-puppet'
+import {
+  log,
+  type LoggerLike,
+}                     from '@juzi/wechaty-puppet'
 import {
   grpc,
   puppet,
@@ -89,7 +91,7 @@ class GrpcManager extends EventEmitter {
     this.caCert = Buffer.from(
       envVars.WECHATY_PUPPET_SERVICE_TLS_CA_CERT(this.options.tls?.caCert) || TLS_CA_CERT,
     )
-    log.verbose('GrpcManager', 'constructor() tlsRootCert(hash): "%s"',
+    this._log.verbose('GrpcManager', 'constructor() tlsRootCert(hash): "%s"',
       crypto.createHash('sha256')
         .update(this.caCert)
         .digest('hex'),
@@ -101,7 +103,7 @@ class GrpcManager extends EventEmitter {
     this.token = new WechatyToken(
       envVars.WECHATY_PUPPET_SERVICE_TOKEN(this.options.token),
     )
-    log.verbose('GrpcManager', 'constructor() token: "%s"', this.token)
+    this._log.verbose('GrpcManager', 'constructor() token: "%s"', this.token)
 
     this.endpoint = envVars.WECHATY_PUPPET_SERVICE_ENDPOINT(this.options.endpoint)
       /**
@@ -114,13 +116,13 @@ class GrpcManager extends EventEmitter {
         '/',
         this.token,
       ].join('')
-    log.verbose('GrpcManager', 'constructor() endpoint: "%s"', this.endpoint)
+    this._log.verbose('GrpcManager', 'constructor() endpoint: "%s"', this.endpoint)
 
     /**
      * Disable TLS
      */
     this.disableTls = envVars.WECHATY_PUPPET_SERVICE_NO_TLS_INSECURE_CLIENT(this.options.tls?.disable)
-    log.verbose('GrpcManager', 'constructor() disableTls: "%s"', this.disableTls)
+    this._log.verbose('GrpcManager', 'constructor() disableTls: "%s"', this.disableTls)
 
     /**
      * for Node.js TLS SNI
@@ -145,59 +147,59 @@ class GrpcManager extends EventEmitter {
     }
 
     this.serverName = serverNameIndication
-    log.verbose('GrpcManager', 'constructor() serverName(SNI): "%s"', this.serverName)
+    this._log.verbose('GrpcManager', 'constructor() serverName(SNI): "%s"', this.serverName)
   }
 
   async start (lastEventSeq?: string, accountId?: string): Promise<void> {
-    log.verbose('GrpcManager', 'start()')
+    this._log.verbose('GrpcManager', 'start()')
 
     /**
      * 1. Init grpc client
      */
-    log.verbose('GrpcManager', 'start() initializing client ...')
+    this._log.verbose('GrpcManager', 'start() initializing client ...')
     await this.initClient()
-    log.verbose('GrpcManager', 'start() initializing client ... done')
+    this._log.verbose('GrpcManager', 'start() initializing client ... done')
 
     /**
      * 2. Connect to stream
      */
-    log.verbose('GrpcManager', 'start() starting stream ...')
+    this._log.verbose('GrpcManager', 'start() starting stream ...')
     await this.startStream(lastEventSeq, accountId)
-    log.verbose('GrpcManager', 'start() starting stream ... done')
+    this._log.verbose('GrpcManager', 'start() starting stream ... done')
 
     /**
      * 3. Start the puppet
      */
-    log.verbose('GrpcManager', 'start() calling grpc server: start() ...')
+    this._log.verbose('GrpcManager', 'start() calling grpc server: start() ...')
     await util.promisify(
       this.client.start
         .bind(this.client),
     )(new puppet.StartRequest())
-    log.verbose('GrpcManager', 'start() calling grpc server: start() ... done')
+    this._log.verbose('GrpcManager', 'start() calling grpc server: start() ... done')
 
-    log.verbose('GrpcManager', 'start() ... done')
+    this._log.verbose('GrpcManager', 'start() ... done')
   }
 
   async stop (): Promise<void> {
-    log.verbose('GrpcManager', 'stop()')
+    this._log.verbose('GrpcManager', 'stop()')
 
     /**
      * 1. Disconnect from stream
      */
-    log.verbose('GrpcManager', 'stop() stop stream ...')
+    this._log.verbose('GrpcManager', 'stop() stop stream ...')
     this.stopStream()
-    log.verbose('GrpcManager', 'stop() stop stream ... done')
+    this._log.verbose('GrpcManager', 'stop() stop stream ... done')
 
     /**
      * 2. Stop the puppet
      */
     try {
-      log.verbose('GrpcManager', 'stop() stop client ...')
+      this._log.verbose('GrpcManager', 'stop() stop client ...')
       await util.promisify(
         this.client.stop
           .bind(this.client),
       )(new puppet.StopRequest())
-      log.verbose('GrpcManager', 'stop() stop client ... done')
+      this._log.verbose('GrpcManager', 'stop() stop client ... done')
     } catch (e) {
       this.emit('error', e)
     }
@@ -206,18 +208,18 @@ class GrpcManager extends EventEmitter {
      * 3. Destroy grpc client
      */
     try {
-      log.verbose('GrpcManager', 'stop() destroy client ...')
+      this._log.verbose('GrpcManager', 'stop() destroy client ...')
       this.destroyClient()
-      log.verbose('GrpcManager', 'stop() destroy client ... done')
+      this._log.verbose('GrpcManager', 'stop() destroy client ... done')
     } catch (e) {
       this.emit('error', e)
     }
 
-    log.verbose('GrpcManager', 'stop() ... done')
+    this._log.verbose('GrpcManager', 'stop() ... done')
   }
 
   protected async initClient (): Promise<void> {
-    log.verbose('GrpcManager', 'initClient()')
+    this._log.verbose('GrpcManager', 'initClient()')
 
     /**
      * Huan(202108): for maximum compatible with the non-tls community servers/clients,
@@ -226,10 +228,10 @@ class GrpcManager extends EventEmitter {
      */
     let credential
     if (this.disableTls) {
-      log.warn('GrpcManager', 'initClient() TLS: disabled (INSECURE)')
+      this._log.warn('GrpcManager', 'initClient() TLS: disabled (INSECURE)')
       credential = grpc.credentials.createInsecure()
     } else {
-      log.verbose('GrpcManager', 'initClient() TLS: enabled')
+      this._log.verbose('GrpcManager', 'initClient() TLS: enabled')
       const callCred    = callCredToken(this.token.token)
       const channelCred = grpc.credentials.createSsl(this.caCert)
       const combCreds   = grpc.credentials.combineChannelCredentials(channelCred, callCred)
@@ -256,7 +258,7 @@ class GrpcManager extends EventEmitter {
     }
 
     if (this._client) {
-      log.warn('GrpcManager', 'initClient() this.#client exists? Old client has been dropped.')
+      this._log.warn('GrpcManager', 'initClient() this.#client exists? Old client has been dropped.')
       this._client = undefined
     }
 
@@ -266,14 +268,14 @@ class GrpcManager extends EventEmitter {
       clientOptions,
     )
 
-    log.verbose('GrpcManager', 'initClient() ... done')
+    this._log.verbose('GrpcManager', 'initClient() ... done')
   }
 
   protected destroyClient (): void {
-    log.verbose('GrpcManager', 'destroyClient()')
+    this._log.verbose('GrpcManager', 'destroyClient()')
 
     if (!this._client) {
-      log.warn('GrpcManager', 'destroyClient() this.#client not exist')
+      this._log.warn('GrpcManager', 'destroyClient() this.#client not exist')
       return
     }
 
@@ -287,19 +289,19 @@ class GrpcManager extends EventEmitter {
     try {
       client.close()
     } catch (e) {
-      log.error('GrpcManager', 'destroyClient() client.close() rejection: %s\n%s', e && (e as Error).message, (e as Error).stack)
+      this._log.error('GrpcManager', 'destroyClient() client.close() rejection: %s\n%s', e && (e as Error).message, (e as Error).stack)
     }
   }
 
   async startStream (lastEventSeq?: string, accountId?: string): Promise<void> {
-    log.verbose('GrpcManager', 'startStream()')
+    this._log.verbose('GrpcManager', 'startStream()')
 
     if (this.eventStream) {
-      log.verbose('GrpcManager', 'startStream() this.eventStream exists, dropped.')
+      this._log.verbose('GrpcManager', 'startStream() this.eventStream exists, dropped.')
       this.eventStream = undefined
     }
 
-    log.verbose('GrpcManager', 'startStream() grpc -> event() ...')
+    this._log.verbose('GrpcManager', 'startStream() grpc -> event() ...')
 
     const eventRequest = new puppet.EventRequest()
     if (lastEventSeq) {
@@ -308,10 +310,10 @@ class GrpcManager extends EventEmitter {
     if (accountId) {
       eventRequest.setAccountId(accountId)
     }
-    log.info('GrpcManager', `startStream() connecting event stream with account ${accountId} and seq ${lastEventSeq}`)
+    this._log.info('GrpcManager', `startStream() connecting event stream with account ${accountId} and seq ${lastEventSeq}`)
 
     const eventStream = this.client.event(eventRequest)
-    log.verbose('GrpcManager', 'startStream() grpc -> event() ... done')
+    this._log.verbose('GrpcManager', 'startStream() grpc -> event() ... done')
 
     /**
      * Store the event data from the stream when we test connection,
@@ -378,13 +380,13 @@ class GrpcManager extends EventEmitter {
      *  if a puppet service provider is coming from the community, it might not follow the protocol specification.
      * So we need a timeout for compatible with those providers
      */
-    log.verbose('GrpcManager', 'startStream() grpc -> event peeking data or timeout ...')
+    this._log.verbose('GrpcManager', 'startStream() grpc -> event peeking data or timeout ...')
     try {
       await timeoutPromise(future, 5 * 1000)  // 5 seconds
     } catch (_) {
-      log.verbose('GrpcManager', 'startStream() grpc -> event peeking data or timeout ... timeout')
+      this._log.verbose('GrpcManager', 'startStream() grpc -> event peeking data or timeout ... timeout')
     }
-    log.verbose('GrpcManager', 'startStream() grpc -> event peeking data or timeout ... data peeked')
+    this._log.verbose('GrpcManager', 'startStream() grpc -> event peeking data or timeout ... data peeked')
 
     /**
      * Bridge the events
@@ -393,7 +395,7 @@ class GrpcManager extends EventEmitter {
      *  so that if there's any `error` event,
      *  it will be triggered already.
      */
-    log.verbose('GrpcManager', 'startStream() initializing event stream ...')
+    this._log.verbose('GrpcManager', 'startStream() initializing event stream ...')
     eventStream
       .on('cancel',   (...args) => this.emit('cancel',    ...args))
       .on('data',     (...args) => this.emit('data',      ...args))
@@ -403,26 +405,26 @@ class GrpcManager extends EventEmitter {
       .on('status',   (...args) => this.emit('status',    ...args))
 
     this.eventStream = eventStream
-    log.verbose('GrpcManager', 'startStream() initializing event stream ... done')
+    this._log.verbose('GrpcManager', 'startStream() initializing event stream ... done')
 
     /**
      * Re-emit the peeked data if there' s any
      */
     if (peekedData) {
-      log.verbose('GrpcManager', 'startStream() sending back the peeked data ...')
+      this._log.verbose('GrpcManager', 'startStream() sending back the peeked data ...')
       this.emit('data', peekedData)
       peekedData = undefined
-      log.verbose('GrpcManager', 'startStream() sending back the peeked data ... done')
+      this._log.verbose('GrpcManager', 'startStream() sending back the peeked data ... done')
     }
 
-    log.verbose('GrpcManager', 'startStream() ... done')
+    this._log.verbose('GrpcManager', 'startStream() ... done')
   }
 
   stopStream (): void {
-    log.verbose('GrpcManager', 'stopStream()')
+    this._log.verbose('GrpcManager', 'stopStream()')
 
     if (!this.eventStream) {
-      log.verbose('GrpcManager', 'stopStream() no eventStream when stop, skip destroy.')
+      this._log.verbose('GrpcManager', 'stopStream() no eventStream when stop, skip destroy.')
       return
     }
     /**
@@ -440,9 +442,9 @@ class GrpcManager extends EventEmitter {
     // this.eventStream.cancel()
 
     try {
-      log.verbose('GrpcManager', 'stopStream() destroying event stream ...')
+      this._log.verbose('GrpcManager', 'stopStream() destroying event stream ...')
       eventStream.destroy()
-      log.verbose('GrpcManager', 'stopStream() destroying event stream ... done')
+      this._log.verbose('GrpcManager', 'stopStream() destroying event stream ... done')
     } catch (e) {
       this.emit('error', e)
     }

--- a/src/client/grpc-manager.ts
+++ b/src/client/grpc-manager.ts
@@ -22,6 +22,7 @@ import EventEmitter from 'events'
 import crypto from 'crypto'
 
 import { log } from '@juzi/wechaty-puppet'
+import type { LoggerLike } from '@juzi/wechaty-puppet'
 import {
   grpc,
   puppet,
@@ -78,9 +79,12 @@ class GrpcManager extends EventEmitter {
   serverName : string
   token      : WechatyToken
 
+  private readonly _log: LoggerLike
+
   constructor (private options: PuppetServiceOptions) {
     super()
-    log.verbose('GrpcManager', 'constructor(%s)', JSON.stringify(options))
+    this._log = options.logger ?? log
+    this._log.verbose('GrpcManager', 'constructor(%s)', JSON.stringify(options))
 
     this.caCert = Buffer.from(
       envVars.WECHATY_PUPPET_SERVICE_TLS_CA_CERT(this.options.tls?.caCert) || TLS_CA_CERT,

--- a/src/client/payload-store.ts
+++ b/src/client/payload-store.ts
@@ -24,6 +24,7 @@ import fs from 'fs'
 import semverPkg from 'semver'
 
 import type * as PUPPET from '@juzi/wechaty-puppet'
+import type { LoggerLike } from '@juzi/wechaty-puppet'
 
 import { FlashStore } from 'flash-store'
 
@@ -36,7 +37,8 @@ import { WECHATY_PUPPET_SERVICE_DISABLE_EVENT_CACHE } from '../env-vars.js'
 const { major, minor } = semverPkg
 
 interface PayloadStoreOptions {
-  token: string
+  token   : string
+  logger? : LoggerLike
 }
 
 interface StoreRoomMemberPayload {
@@ -57,8 +59,11 @@ class PayloadStore {
   protected storeDir:   string
   protected accountId?: string
 
+  private readonly _log: LoggerLike
+
   constructor (private options: PayloadStoreOptions) {
-    log.verbose('PayloadStore', 'constructor(%s)', JSON.stringify(options))
+    this._log = options.logger ?? log
+    this._log.verbose('PayloadStore', 'constructor(%s)', JSON.stringify(options))
 
     this.storeDir = path.join(
       os.homedir(),

--- a/src/client/payload-store.ts
+++ b/src/client/payload-store.ts
@@ -24,7 +24,6 @@ import fs from 'fs'
 import semverPkg from 'semver'
 
 import type * as PUPPET from '@juzi/wechaty-puppet'
-import type { LoggerLike } from '@juzi/wechaty-puppet'
 
 import { FlashStore } from 'flash-store'
 
@@ -33,6 +32,8 @@ import {
   log,
 }             from '../config.js'
 import { WECHATY_PUPPET_SERVICE_DISABLE_EVENT_CACHE } from '../env-vars.js'
+
+type LoggerLike = PUPPET.LoggerLike
 
 const { major, minor } = semverPkg
 
@@ -72,7 +73,7 @@ class PayloadStore {
       this.options.token,
       `v${major(VERSION)}.${minor(VERSION)}`,
     )
-    log.silly('PayloadStore', 'constructor() storeDir: "%s"', this.storeDir)
+    this._log.silly('PayloadStore', 'constructor() storeDir: "%s"', this.storeDir)
 
     if (!fs.existsSync(this.storeDir)) {
       fs.mkdirSync(this.storeDir, { recursive: true })
@@ -88,7 +89,7 @@ class PayloadStore {
    *  so that we can save the payloads under a specific account folder.
    */
   async start (accountId: string): Promise<void> {
-    log.verbose('PayloadStore', 'start(%s)', accountId)
+    this._log.verbose('PayloadStore', 'start(%s)', accountId)
 
     if (this.accountId) {
       throw new Error('PayloadStore should be stop() before start() again.')
@@ -117,7 +118,7 @@ class PayloadStore {
      */
     // const lruOptions: LRU.Options<string, MessagePayload> = {
     //   dispose (key, val) {
-    //     log.silly('PayloadStore', `constructor() lruOptions.dispose(${key}, ${JSON.stringify(val)})`)
+    //     this._log.silly('PayloadStore', `constructor() lruOptions.dispose(${key}, ${JSON.stringify(val)})`)
     //   },
     //   max    : 1000,  // 1000 messages
     //   maxAge : 60 * 60 * 1000,  // 1 hour
@@ -126,7 +127,7 @@ class PayloadStore {
   }
 
   async stop (): Promise<void> {
-    log.verbose('PayloadStore', 'stop()')
+    this._log.verbose('PayloadStore', 'stop()')
 
     const contactStore    = this.contact
     const roomMemberStore = this.roomMember
@@ -158,7 +159,7 @@ class PayloadStore {
   }
 
   async destroy (): Promise<void> {
-    log.verbose('PayloadStore', 'destroy()')
+    this._log.verbose('PayloadStore', 'destroy()')
     if (this.accountId) {
       throw new Error('Can not destroy() a start()-ed store. Call stop() to stop it first')
     }

--- a/src/client/puppet-service.ts
+++ b/src/client/puppet-service.ts
@@ -73,6 +73,15 @@ export type PuppetServiceOptions = PUPPET.PuppetOptions & {
   }
 }
 
+/**
+ * Local stand-in for the pluggable logger contract that will be exported by
+ * `@juzi/wechaty-puppet` once its logger-injection refactor lands.
+ *
+ * TODO(pluggable-logger): replace with `import type { LoggerLike } from
+ * '@juzi/wechaty-puppet'` after the base package publishes the type.
+ */
+type LoggerLike = typeof log
+
 const ResetLoginTimeout = 30 * 1000
 const ResetReadyTimeout = 20 * 1000 // normally ready comes 15 seconds after login
 
@@ -108,6 +117,17 @@ class PuppetService extends PUPPET.Puppet {
 
   static override readonly VERSION = VERSION
 
+  /**
+   * Kept until the Puppet base class in `@juzi/wechaty-puppet` ships `log`
+   * as an inherited field. `declare` emits no runtime code, so it neither
+   * shadows a future base declaration nor conflicts with older ones — it only
+   * teaches TypeScript that `this.log` exists when we fall back below.
+   *
+   * TODO(pluggable-logger): drop this declaration once we depend on a
+   * wechaty-puppet version that owns `log` on the Puppet base.
+   */
+  declare log: LoggerLike
+
   protected _payloadStore: PayloadStore
 
   private timeoutMilliseconds: number
@@ -132,6 +152,18 @@ class PuppetService extends PUPPET.Puppet {
     public override options: PuppetServiceOptions = {},
   ) {
     super(options)
+    /**
+     * Compatibility fallback for older `@juzi/wechaty-puppet` versions whose
+     * Puppet base class does not honor `options.logger` and therefore never
+     * initializes `this.log`. Newer versions set `this.log` inside `super()`
+     * (from `options.logger` or the default brolog), leaving this a no-op.
+     *
+     * TypeScript sees `this.log` as always defined via the `declare` field, but
+     * that guarantee only holds against the newer Puppet base — the eslint
+     * warning below is the price of runtime-defensive coding here.
+     */
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    this.log ??= log
     this._payloadStore = new PayloadStore({
       token: envVars.WECHATY_PUPPET_SERVICE_TOKEN(this.options.token),
     })

--- a/src/client/puppet-service.ts
+++ b/src/client/puppet-service.ts
@@ -73,15 +73,6 @@ export type PuppetServiceOptions = PUPPET.PuppetOptions & {
   }
 }
 
-/**
- * Local stand-in for the pluggable logger contract that will be exported by
- * `@juzi/wechaty-puppet` once its logger-injection refactor lands.
- *
- * TODO(pluggable-logger): replace with `import type { LoggerLike } from
- * '@juzi/wechaty-puppet'` after the base package publishes the type.
- */
-type LoggerLike = typeof log
-
 const ResetLoginTimeout = 30 * 1000
 const ResetReadyTimeout = 20 * 1000 // normally ready comes 15 seconds after login
 
@@ -117,17 +108,6 @@ class PuppetService extends PUPPET.Puppet {
 
   static override readonly VERSION = VERSION
 
-  /**
-   * Kept until the Puppet base class in `@juzi/wechaty-puppet` ships `log`
-   * as an inherited field. `declare` emits no runtime code, so it neither
-   * shadows a future base declaration nor conflicts with older ones — it only
-   * teaches TypeScript that `this.log` exists when we fall back below.
-   *
-   * TODO(pluggable-logger): drop this declaration once we depend on a
-   * wechaty-puppet version that owns `log` on the Puppet base.
-   */
-  declare log: LoggerLike
-
   protected _payloadStore: PayloadStore
 
   private timeoutMilliseconds: number
@@ -152,18 +132,6 @@ class PuppetService extends PUPPET.Puppet {
     public override options: PuppetServiceOptions = {},
   ) {
     super(options)
-    /**
-     * Compatibility fallback for older `@juzi/wechaty-puppet` versions whose
-     * Puppet base class does not honor `options.logger` and therefore never
-     * initializes `this.log`. Newer versions set `this.log` inside `super()`
-     * (from `options.logger` or the default brolog), leaving this a no-op.
-     *
-     * TypeScript sees `this.log` as always defined via the `declare` field, but
-     * that guarantee only holds against the newer Puppet base — the eslint
-     * warning below is the price of runtime-defensive coding here.
-     */
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    this.log ??= log
     this._payloadStore = new PayloadStore({
       token: envVars.WECHATY_PUPPET_SERVICE_TOKEN(this.options.token),
     })

--- a/src/client/puppet-service.ts
+++ b/src/client/puppet-service.ts
@@ -133,7 +133,8 @@ class PuppetService extends PUPPET.Puppet {
   ) {
     super(options)
     this._payloadStore = new PayloadStore({
-      token: envVars.WECHATY_PUPPET_SERVICE_TOKEN(this.options.token),
+      token  : envVars.WECHATY_PUPPET_SERVICE_TOKEN(this.options.token),
+      logger : this.options.logger,
     })
 
     this.hookPayloadStore()

--- a/src/client/puppet-service.ts
+++ b/src/client/puppet-service.ts
@@ -209,19 +209,19 @@ class PuppetService extends PUPPET.Puppet {
   }
 
   override async onStart (): Promise<void> {
-    log.verbose('PuppetService', 'onStart()')
+    this.log.verbose('PuppetService', 'onStart()')
 
     this.waitingForLogin = false
     this.waitingForReady = false
 
     if (this._grpcManager) {
-      log.warn('PuppetService', 'onStart() found this.grpc is already existed. dropped.')
+      this.log.warn('PuppetService', 'onStart() found this.grpc is already existed. dropped.')
       this._grpcManager = undefined
     }
 
-    log.info('PuppetService', 'start() instanciating GrpcManager ...')
+    this.log.info('PuppetService', 'start() instanciating GrpcManager ...')
     const grpcManager = new GrpcManager(this.options)
-    log.info('PuppetService', 'start() instanciating GrpcManager ... done')
+    this.log.info('PuppetService', 'start() instanciating GrpcManager ... done')
 
     /**
      * Huan(202108): when we started the event stream,
@@ -229,71 +229,71 @@ class PuppetService extends PUPPET.Puppet {
      */
     this._grpcManager = grpcManager
 
-    log.info('PuppetService', 'start() setting up bridge grpc event stream ...')
+    this.log.info('PuppetService', 'start() setting up bridge grpc event stream ...')
     this.bridgeGrpcEventStream(grpcManager)
-    log.info('PuppetService', 'start() setting up bridge grpc event stream ... done')
+    this.log.info('PuppetService', 'start() setting up bridge grpc event stream ... done')
 
-    log.info('PuppetService', 'start() starting grpc manager...')
+    this.log.info('PuppetService', 'start() starting grpc manager...')
     const { lastEventSeq, accountId } = await this.getMiscellaneousStoreData()
     await grpcManager.start(lastEventSeq, accountId)
-    log.info('PuppetService', 'start() starting grpc manager... done')
+    this.log.info('PuppetService', 'start() starting grpc manager... done')
 
-    log.info('PuppetService', 'start healthCheck')
+    this.log.info('PuppetService', 'start healthCheck')
     this.startHealthCheck()
 
-    log.info('PuppetService', 'onStart() ... done')
+    this.log.info('PuppetService', 'onStart() ... done')
   }
 
   override async onStop (): Promise<void> {
-    log.info('PuppetService', 'onStop()')
+    this.log.info('PuppetService', 'onStop()')
 
     if (this._grpcManager) {
-      log.info('PuppetService', 'onStop() stopping grpc manager ...')
+      this.log.info('PuppetService', 'onStop() stopping grpc manager ...')
       const grpcManager = this._grpcManager
       this._grpcManager = undefined
       await grpcManager.stop()
-      log.info('PuppetService', 'onStop() stopping grpc manager ... done')
+      this.log.info('PuppetService', 'onStop() stopping grpc manager ... done')
     }
 
-    log.info('PuppetService', 'onStop() ... done')
-    log.info('PuppetService', 'stop healthCheck')
+    this.log.info('PuppetService', 'onStop() ... done')
+    this.log.info('PuppetService', 'stop healthCheck')
     this.stopHealthCheck()
   }
 
   protected hookPayloadStore (): void {
-    log.verbose('PuppetService', 'hookPayloadStore()')
+    this.log.verbose('PuppetService', 'hookPayloadStore()')
 
     this.on('login',  async ({ contactId }) => {
       try {
-        log.verbose('PuppetService', 'hookPayloadStore() this.on(login) contactId: "%s"', contactId)
+        this.log.verbose('PuppetService', 'hookPayloadStore() this.on(login) contactId: "%s"', contactId)
         await this._payloadStore.start(contactId)
       } catch (e) {
-        log.verbose('PuppetService', 'hookPayloadStore() this.on(login) rejection "%s"', (e as Error).message)
+        this.log.verbose('PuppetService', 'hookPayloadStore() this.on(login) rejection "%s"', (e as Error).message)
       }
     })
 
     this.on('logout', async ({ contactId }) => {
-      log.verbose('PuppetService', 'hookPayloadStore() this.on(logout) contactId: "%s"', contactId)
+      this.log.verbose('PuppetService', 'hookPayloadStore() this.on(logout) contactId: "%s"', contactId)
       try {
         await this._payloadStore.stop()
       } catch (e) {
-        log.verbose('PuppetService', 'hookPayloadStore() this.on(logout) rejection "%s"', (e as Error).message)
+        this.log.verbose('PuppetService', 'hookPayloadStore() this.on(logout) rejection "%s"', (e as Error).message)
       }
     })
   }
 
   protected bridgeGrpcEventStream (client: GrpcManager): void {
-    log.verbose('PuppetService', 'bridgeGrpcEventStream(client)')
+    this.log.verbose('PuppetService', 'bridgeGrpcEventStream(client)')
 
     client
       .on('data', this.onGrpcStreamEvent.bind(this) as any)
       .on('end', () => {
-        log.verbose('PuppetService', 'bridgeGrpcEventStream() eventStream.on(end)')
+        this.log.verbose('PuppetService', 'bridgeGrpcEventStream() eventStream.on(end)')
       })
       .on('error', (e: unknown) => {
         this.emit('error', e)
         // https://github.com/wechaty/wechaty-puppet-service/issues/16
-        // log.verbose('PuppetService', 'bridgeGrpcEventStream() eventStream.on(error) %s', e)
+        // this.log.verbose('PuppetService', 'bridgeGrpcEventStream() eventStream.on(error) %s', e)
         // const reason = 'bridgeGrpcEventStream() eventStream.on(error) ' + e
         /**
          * Huan(202110): simple reset puppet when grpc client has error? (or not?)
@@ -308,7 +308,7 @@ class PuppetService extends PUPPET.Puppet {
         // }
       })
       .on('cancel', (...args: any[]) => {
-        log.verbose('PuppetService', 'bridgeGrpcEventStream() eventStream.on(cancel), %s', JSON.stringify(args))
+        this.log.verbose('PuppetService', 'bridgeGrpcEventStream() eventStream.on(cancel), %s', JSON.stringify(args))
       })
   }
 
@@ -320,10 +320,10 @@ class PuppetService extends PUPPET.Puppet {
     const timestamp = String(Date.now())
 
     if (!NO_LOG_EVENTS.includes(type)) {
-      log.info('PuppetService', `received grpc event ${EventTypeRev[type]} on ${new Date().toString()}, content: ${JSON.stringify(payload)}, seq: ${seq}, timestamp: ${timestamp}`)
+      this.log.info('PuppetService', `received grpc event ${EventTypeRev[type]} on ${new Date().toString()}, content: ${JSON.stringify(payload)}, seq: ${seq}, timestamp: ${timestamp}`)
     }
 
-    log.silly('PuppetService',
+    this.log.silly('PuppetService',
       'onGrpcStreamEvent({type:%s(%s), payload:"%s"})',
       EventTypeRev[type],
       type,
@@ -362,7 +362,7 @@ class PuppetService extends PUPPET.Puppet {
       case grpcPuppet.EventType.EVENT_TYPE_LOGIN:
         {
           if (this.waitingForLogin && this.isLoggedIn) {
-            log.warn('PuppetService', 'this login event is ignored because the it is expected by event stream reconnect and this puppet is already logged in')
+            this.log.warn('PuppetService', 'this login event is ignored because the it is expected by event stream reconnect and this puppet is already logged in')
             return
           }
           const loginPayload = JSON.parse(payload) as PUPPET.payloads.EventLogin
@@ -378,7 +378,7 @@ class PuppetService extends PUPPET.Puppet {
           (
             async () => this.login(loginPayload.contactId)
           )().catch(e =>
-            log.error('PuppetService', 'onGrpcStreamEvent() this.login() rejection %s',
+            this.log.error('PuppetService', 'onGrpcStreamEvent() this.login() rejection %s',
               (e as Error).message,
             ),
           )
@@ -393,7 +393,7 @@ class PuppetService extends PUPPET.Puppet {
           ;(
             async () => this.logout(logoutPayload.data)
           )().catch(e =>
-            log.error('PuppetService', 'onGrpcStreamEvent() this.logout() rejection %s',
+            this.log.error('PuppetService', 'onGrpcStreamEvent() this.logout() rejection %s',
               (e as Error).message,
             ),
           )
@@ -419,7 +419,7 @@ class PuppetService extends PUPPET.Puppet {
         break
       case grpcPuppet.EventType.EVENT_TYPE_READY:
         if (this.waitingForReady && this.readyIndicator.value()) {
-          log.warn('PuppetService', 'this ready event is ignored because the it is expected by event stream reconnect and this puppet is already ready')
+          this.log.warn('PuppetService', 'this ready event is ignored because the it is expected by event stream reconnect and this puppet is already ready')
           return
         }
         this.emit('ready', JSON.parse(payload) as PUPPET.payloads.EventReady)
@@ -449,14 +449,14 @@ class PuppetService extends PUPPET.Puppet {
         this.emit('tag-group', JSON.parse(payload) as PUPPET.payloads.EventTagGroup)
         break
       case grpcPuppet.EventType.EVENT_TYPE_RESET:
-        log.warn('PuppetService', 'onGrpcStreamEvent() got an EventType.EVENT_TYPE_RESET ?')
+        this.log.warn('PuppetService', 'onGrpcStreamEvent() got an EventType.EVENT_TYPE_RESET ?')
         // the `reset` event should be dealed not send out
         break
       case grpcPuppet.EventType.EVENT_TYPE_VERIFY_CODE:
         this.emit('verify-code', JSON.parse(payload) as PUPPET.payloads.EventVerifyCode)
         break
       case grpcPuppet.EventType.EVENT_TYPE_UNSPECIFIED:
-        log.error('PuppetService', 'onGrpcStreamEvent() got an EventType.EVENT_TYPE_UNSPECIFIED ?')
+        this.log.error('PuppetService', 'onGrpcStreamEvent() got an EventType.EVENT_TYPE_UNSPECIFIED ?')
         break
       case grpcPuppet.EventType.EVENT_TYPE_VERIFY_SLIDE:
         this.emit('verify-slide', JSON.parse(payload) as PUPPET.payloads.EventVerifySlide)
@@ -467,12 +467,12 @@ class PuppetService extends PUPPET.Puppet {
 
       default:
         // Huan(202003): in default, the `type` type should be `never`, please check.
-        log.error(`eventType ${type} unsupported! data: ${payload}`)
+        this.log.error(`eventType ${type} unsupported! data: ${payload}`)
     }
   }
 
   override async logout (reason?: string): Promise<void> {
-    log.verbose('PuppetService', 'logout(%s)', reason ? `"${reason}"` : '')
+    this.log.verbose('PuppetService', 'logout(%s)', reason ? `"${reason}"` : '')
 
     await super.logout(reason)
 
@@ -483,12 +483,12 @@ class PuppetService extends PUPPET.Puppet {
       )(new grpcPuppet.LogoutRequest())
 
     } catch (e) {
-      log.silly('PuppetService', 'logout() no grpc client')
+      this.log.silly('PuppetService', 'logout() no grpc client')
     }
   }
 
   override ding (data: string): void {
-    log.silly('PuppetService', 'ding(%s)', data)
+    this.log.silly('PuppetService', 'ding(%s)', data)
 
     const request = new grpcPuppet.DingRequest()
     request.setData(data || '')
@@ -497,7 +497,7 @@ class PuppetService extends PUPPET.Puppet {
       request,
       (error, _response) => {
         if (error) {
-          log.error('PuppetService', 'ding() rejection: %s', error)
+          this.log.error('PuppetService', 'ding() rejection: %s', error)
         }
       },
     )
@@ -512,7 +512,7 @@ class PuppetService extends PUPPET.Puppet {
    *
    */
   override async dirtyPayload (type: PUPPET.types.Dirty, id: string) {
-    log.verbose('PuppetService', 'dirtyPayload(%s, %s)', type, id)
+    this.log.verbose('PuppetService', 'dirtyPayload(%s, %s)', type, id)
 
     const request = new grpcPuppet.DirtyPayloadRequest()
     request.setId(id)
@@ -524,7 +524,7 @@ class PuppetService extends PUPPET.Puppet {
       )(request)
 
     } catch (e) {
-      log.error('PuppetService', 'dirtyPayload() rejection: %s', e && (e as Error).message)
+      this.log.error('PuppetService', 'dirtyPayload() rejection: %s', e && (e as Error).message)
       throw e
     }
   }
@@ -561,7 +561,7 @@ class PuppetService extends PUPPET.Puppet {
       [PUPPET.types.Dirty.Call]:         async (_: string) => {},
       [PUPPET.types.Dirty.Unspecified]:  async (id: string) => {
         const msg = `fastDirty() received Unspecified dirty type (id=${id}); upstream puppet is leaking protobuf default — this is a server-side contract bug`
-        log.error('PuppetService', msg)
+        this.log.error('PuppetService', msg)
         this.emit('error', new Error(msg))
       },
     }
@@ -577,7 +577,7 @@ class PuppetService extends PUPPET.Puppet {
       payloadId,
     }: PUPPET.payloads.EventDirty,
   ): Promise<void> {
-    log.verbose('PuppetService', 'fastDirty(%s<%s>, %s)', PUPPET.types.Dirty[payloadType], payloadType, payloadId)
+    this.log.verbose('PuppetService', 'fastDirty(%s<%s>, %s)', PUPPET.types.Dirty[payloadType], payloadType, payloadId)
 
     // payloadType is typed as the enum, but at runtime the server may emit a
     // value outside our enum (forward-compat). Look it up via a
@@ -585,7 +585,7 @@ class PuppetService extends PUPPET.Puppet {
     const lookup = this._dirtyHandlerMap as Partial<Record<PUPPET.types.Dirty, (id: string) => Promise<unknown>>>
     const handler = lookup[payloadType]
     if (!handler) {
-      log.warn('PuppetService', 'fastDirty() no handler for payloadType=%s', payloadType)
+      this.log.warn('PuppetService', 'fastDirty() no handler for payloadType=%s', payloadType)
       return
     }
 
@@ -597,7 +597,7 @@ class PuppetService extends PUPPET.Puppet {
   }
 
   override async enterVerifyCode (id: string, code: string): Promise<void> {
-    log.verbose('PuppetService', 'enterVerifyCode(%s, %s)', id, code)
+    this.log.verbose('PuppetService', 'enterVerifyCode(%s, %s)', id, code)
 
     const request = new grpcPuppet.EnterVerifyCodeRequest()
     request.setId(id)
@@ -610,7 +610,7 @@ class PuppetService extends PUPPET.Puppet {
   }
 
   override async cancelVerifyCode (id: string): Promise<void> {
-    log.verbose('PuppetService', 'cancelVerifyCode(%s)', id)
+    this.log.verbose('PuppetService', 'cancelVerifyCode(%s)', id)
 
     const request = new grpcPuppet.CancelVerifyCodeRequest()
     request.setId(id)
@@ -622,7 +622,7 @@ class PuppetService extends PUPPET.Puppet {
   }
 
   override async refreshQRCode (): Promise<void> {
-    log.verbose('PuppetService', 'refreshQRCode(%s)')
+    this.log.verbose('PuppetService', 'refreshQRCode(%s)')
 
     const request = new grpcPuppet.RefreshQRCodeRequest()
 
@@ -641,7 +641,7 @@ class PuppetService extends PUPPET.Puppet {
   override contactAlias (contactId: string, alias: string | null): Promise<void>
 
   override async contactAlias (contactId: string, alias?: string | null): Promise<void | string> {
-    log.verbose('PuppetService', 'contactAlias(%s, %s)', contactId, alias)
+    this.log.verbose('PuppetService', 'contactAlias(%s, %s)', contactId, alias)
 
     /**
      * Get alias
@@ -693,7 +693,7 @@ class PuppetService extends PUPPET.Puppet {
   }
 
   override async contactPhone (contactId: string, phoneList: string[]): Promise<void> {
-    log.verbose('PuppetService', 'contactPhone(%s, %s)', contactId, phoneList)
+    this.log.verbose('PuppetService', 'contactPhone(%s, %s)', contactId, phoneList)
 
     const request = new grpcPuppet.ContactPhoneRequest()
     request.setContactId(contactId)
@@ -706,7 +706,7 @@ class PuppetService extends PUPPET.Puppet {
   }
 
   override async contactCorporationRemark (contactId: string, corporationRemark: string | null) {
-    log.verbose('PuppetService', 'contactCorporationRemark(%s, %s)', contactId, corporationRemark)
+    this.log.verbose('PuppetService', 'contactCorporationRemark(%s, %s)', contactId, corporationRemark)
 
     const request = new grpcPuppet.ContactCorporationRemarkRequest()
     request.setContactId(contactId)
@@ -730,7 +730,7 @@ class PuppetService extends PUPPET.Puppet {
   }
 
   override async contactDescription (contactId: string, description: string | null) {
-    log.verbose('PuppetService', 'contactDescription(%s, %s)', contactId, description)
+    this.log.verbose('PuppetService', 'contactDescription(%s, %s)', contactId, description)
 
     const request = new grpcPuppet.ContactDescriptionRequest()
     request.setContactId(contactId)
@@ -754,7 +754,7 @@ class PuppetService extends PUPPET.Puppet {
   }
 
   override async contactList (): Promise<string[]> {
-    log.verbose('PuppetService', 'contactList()')
+    this.log.verbose('PuppetService', 'contactList()')
 
     const response = await util.promisify(
       this.grpcManager.client.contactList
@@ -768,7 +768,7 @@ class PuppetService extends PUPPET.Puppet {
   override async contactAvatar (contactId: string, file: FileBoxInterface)  : Promise<void>
 
   override async contactAvatar (contactId: string, fileBox?: FileBoxInterface): Promise<void | FileBoxInterface> {
-    log.verbose('PuppetService', 'contactAvatar(%s)', contactId)
+    this.log.verbose('PuppetService', 'contactAvatar(%s)', contactId)
 
     /**
      * 1. set
@@ -820,11 +820,11 @@ class PuppetService extends PUPPET.Puppet {
   }
 
   override async contactRawPayload (id: string): Promise<PUPPET.payloads.Contact> {
-    log.verbose('PuppetService', 'contactRawPayload(%s)', id)
+    this.log.verbose('PuppetService', 'contactRawPayload(%s)', id)
 
     const cachedPayload = await this._payloadStore.contact?.get(id)
     if (cachedPayload) {
-      log.silly('PuppetService', 'contactRawPayload(%s) cache HIT', id)
+      this.log.silly('PuppetService', 'contactRawPayload(%s) cache HIT', id)
       return cachedPayload
     }
 
@@ -871,19 +871,19 @@ class PuppetService extends PUPPET.Puppet {
     }
 
     await this._payloadStore.contact?.set(id, payload)
-    log.silly('PuppetService', 'contactRawPayload(%s) cache SET', id)
+    this.log.silly('PuppetService', 'contactRawPayload(%s) cache SET', id)
 
     return payload
   }
 
   override async contactRawPayloadParser (payload: PUPPET.payloads.Contact): Promise<PUPPET.payloads.Contact> {
-    // log.silly('PuppetService', 'contactRawPayloadParser({id:%s})', payload.id)
+    // this.log.silly('PuppetService', 'contactRawPayloadParser({id:%s})', payload.id)
     // passthrough
     return payload
   }
 
   override async batchContactRawPayload (contactIdList: string[]): Promise<Map<string, PUPPET.payloads.Contact>> {
-    log.verbose('PuppetService', 'batchContactRawPayload(%s)', contactIdList)
+    this.log.verbose('PuppetService', 'batchContactRawPayload(%s)', contactIdList)
 
     const result = new Map<string, PUPPET.payloads.Contact>()
     const contactIdSet = new Set<string>(contactIdList)
@@ -915,7 +915,7 @@ class PuppetService extends PUPPET.Puppet {
           await this._payloadStore.contact?.set(contactId, puppetPayload)
         }
       } catch (e) {
-        log.error('PuppetService', 'batchContactRawPayload(%s, %s) error: %s, use one by one method', contactIdList, needGetSet, e)
+        this.log.error('PuppetService', 'batchContactRawPayload(%s, %s) error: %s, use one by one method', contactIdList, needGetSet, e)
         for (const contactId of needGetSet) {
           const payload = await this.contactRawPayload(contactId)
           result.set(contactId, payload)
@@ -926,7 +926,7 @@ class PuppetService extends PUPPET.Puppet {
   }
 
   override async contactPayloadModify (contactId: string, payload: Partial<PUPPET.payloads.Contact>): Promise<void> {
-    log.verbose('PuppetService', 'contactPayloadModify(%s, %s)', contactId, JSON.stringify(payload))
+    this.log.verbose('PuppetService', 'contactPayloadModify(%s, %s)', contactId, JSON.stringify(payload))
 
     const request = new grpcPuppet.ContactPayloadModifyRequest()
     request.setId(contactId)
@@ -970,7 +970,7 @@ class PuppetService extends PUPPET.Puppet {
   }
 
   override async contactSelfName (name: string): Promise<void> {
-    log.verbose('PuppetService', 'contactSelfName(%s)', name)
+    this.log.verbose('PuppetService', 'contactSelfName(%s)', name)
 
     const request = new grpcPuppet.ContactSelfNameRequest()
     request.setName(name)
@@ -982,7 +982,7 @@ class PuppetService extends PUPPET.Puppet {
   }
 
   override async contactSelfRealName (realName: string): Promise<void> {
-    log.verbose('PuppetService', 'contactSelfRealName(%s)', realName)
+    this.log.verbose('PuppetService', 'contactSelfRealName(%s)', realName)
 
     const request = new grpcPuppet.ContactSelfRealNameRequest()
     request.setRealName(realName)
@@ -994,7 +994,7 @@ class PuppetService extends PUPPET.Puppet {
   }
 
   override async contactSelfAka (aka: string): Promise<void> {
-    log.verbose('PuppetService', 'contactSelfAka(%s)', aka)
+    this.log.verbose('PuppetService', 'contactSelfAka(%s)', aka)
 
     const request = new grpcPuppet.ContactSelfAkaRequest()
     request.setAka(aka)
@@ -1006,7 +1006,7 @@ class PuppetService extends PUPPET.Puppet {
   }
 
   override async contactSelfQRCode (): Promise<string> {
-    log.verbose('PuppetService', 'contactSelfQRCode()')
+    this.log.verbose('PuppetService', 'contactSelfQRCode()')
 
     const response = await util.promisify(
       this.grpcManager.client.contactSelfQRCode
@@ -1017,7 +1017,7 @@ class PuppetService extends PUPPET.Puppet {
   }
 
   override async contactSelfSignature (signature: string): Promise<void> {
-    log.verbose('PuppetService', 'contactSelfSignature(%s)', signature)
+    this.log.verbose('PuppetService', 'contactSelfSignature(%s)', signature)
 
     const request = new grpcPuppet.ContactSelfSignatureRequest()
     request.setSignature(signature)
@@ -1029,7 +1029,7 @@ class PuppetService extends PUPPET.Puppet {
   }
 
   override async contactSelfRoomAlias (roomId: string, alias: string): Promise<void> {
-    log.verbose('PuppetService', 'contactSelfRoomAlias(%s, %s)', roomId, alias)
+    this.log.verbose('PuppetService', 'contactSelfRoomAlias(%s, %s)', roomId, alias)
 
     const request = new grpcPuppet.ContactSelfRoomAliasRequest()
     request.setRoomId(roomId)
@@ -1042,7 +1042,7 @@ class PuppetService extends PUPPET.Puppet {
   }
 
   override async contactDelete (contactId: string): Promise<void> {
-    log.verbose('PuppetService', 'contactDelete(%s)', contactId)
+    this.log.verbose('PuppetService', 'contactDelete(%s)', contactId)
     const request = new grpcPuppet.ContactDeleteRequest()
     request.setContactId(contactId)
 
@@ -1061,7 +1061,7 @@ class PuppetService extends PUPPET.Puppet {
     conversationId: string,
     hasRead = true,
   ) : Promise<void> {
-    log.verbose('PuppetService', 'conversationMarkRead(%s, %s)', conversationId, hasRead)
+    this.log.verbose('PuppetService', 'conversationMarkRead(%s, %s)', conversationId, hasRead)
 
     const request = new grpcPuppet.ConversationReadRequest()
     request.setConversationId(conversationId)
@@ -1081,7 +1081,7 @@ class PuppetService extends PUPPET.Puppet {
   override async messageMiniProgram (
     messageId: string,
   ): Promise<PUPPET.payloads.MiniProgram> {
-    log.verbose('PuppetService', 'messageMiniProgram(%s)', messageId)
+    this.log.verbose('PuppetService', 'messageMiniProgram(%s)', messageId)
 
     const request = new grpcPuppet.MessageMiniProgramRequest()
     request.setId(messageId)
@@ -1110,7 +1110,7 @@ class PuppetService extends PUPPET.Puppet {
   override async messageLocation (
     messageId: string,
   ): Promise<PUPPET.payloads.Location> {
-    log.verbose('PuppetService', 'messageLocation(%s)', messageId)
+    this.log.verbose('PuppetService', 'messageLocation(%s)', messageId)
 
     const request = new grpcPuppet.MessageLocationRequest()
     request.setId(messageId)
@@ -1136,7 +1136,7 @@ class PuppetService extends PUPPET.Puppet {
     messageId: string,
     imageType: PUPPET.types.Image,
   ): Promise<FileBoxInterface> {
-    log.verbose('PuppetService', 'messageImage(%s, %s[%s])',
+    this.log.verbose('PuppetService', 'messageImage(%s, %s[%s])',
       messageId,
       imageType,
       PUPPET.types.Image[imageType],
@@ -1162,7 +1162,7 @@ class PuppetService extends PUPPET.Puppet {
   override async messageContact (
     messageId: string,
   ): Promise<string> {
-    log.verbose('PuppetService', 'messageContact(%s)', messageId)
+    this.log.verbose('PuppetService', 'messageContact(%s)', messageId)
 
     const request = new grpcPuppet.MessageContactRequest()
     request.setId(messageId)
@@ -1179,7 +1179,7 @@ class PuppetService extends PUPPET.Puppet {
   override async messageChannel (
     messageId: string,
   ): Promise<PUPPET.payloads.Channel> {
-    log.verbose('PuppetService', 'messageChannel(%s)', messageId)
+    this.log.verbose('PuppetService', 'messageChannel(%s)', messageId)
 
     const request = new grpcPuppet.MessageChannelRequest()
     request.setId(messageId)
@@ -1197,7 +1197,7 @@ class PuppetService extends PUPPET.Puppet {
   override async messageChannelCard (
     messageId: string,
   ): Promise<PUPPET.payloads.ChannelCard> {
-    log.verbose('PuppetService', 'messageChannelCard(%s)', messageId)
+    this.log.verbose('PuppetService', 'messageChannelCard(%s)', messageId)
 
     const request = new grpcPuppet.MessageChannelCardRequest()
     request.setId(messageId)
@@ -1215,7 +1215,7 @@ class PuppetService extends PUPPET.Puppet {
   override async messageCallRecord (
     messageId: string,
   ): Promise<PUPPET.payloads.CallRecord> {
-    log.verbose('PuppetService', 'messageCallRecord(%s)', messageId)
+    this.log.verbose('PuppetService', 'messageCallRecord(%s)', messageId)
 
     const request = new grpcPuppet.MessageCallRecordRequest()
     request.setId(messageId)
@@ -1234,7 +1234,7 @@ class PuppetService extends PUPPET.Puppet {
     contactIds: string[],
     media: PUPPET.types.CallMediaType,
   ): Promise<string> {
-    log.verbose('PuppetService', 'callInvite(%s, %s)', contactIds, media)
+    this.log.verbose('PuppetService', 'callInvite(%s, %s)', contactIds, media)
 
     const request = new grpcPuppet.CallInviteRequest()
     request.setContactIdsList(contactIds)
@@ -1257,7 +1257,7 @@ class PuppetService extends PUPPET.Puppet {
     callId: string,
     contactIds: string[],
   ): Promise<void> {
-    log.verbose('PuppetService', 'callAdd(%s, %s)', callId, contactIds)
+    this.log.verbose('PuppetService', 'callAdd(%s, %s)', callId, contactIds)
 
     const request = new grpcPuppet.CallAddRequest()
     request.setCallId(callId)
@@ -1272,7 +1272,7 @@ class PuppetService extends PUPPET.Puppet {
   override async callAccept (
     callId: string,
   ): Promise<void> {
-    log.verbose('PuppetService', 'callAccept(%s)', callId)
+    this.log.verbose('PuppetService', 'callAccept(%s)', callId)
 
     const request = new grpcPuppet.CallAcceptRequest()
     request.setCallId(callId)
@@ -1287,7 +1287,7 @@ class PuppetService extends PUPPET.Puppet {
     callId: string,
     reason?: string,
   ): Promise<void> {
-    log.verbose('PuppetService', 'callReject(%s, %s)', callId, reason)
+    this.log.verbose('PuppetService', 'callReject(%s, %s)', callId, reason)
 
     const request = new grpcPuppet.CallRejectRequest()
     request.setCallId(callId)
@@ -1304,7 +1304,7 @@ class PuppetService extends PUPPET.Puppet {
   override async callCancel (
     callId: string,
   ): Promise<void> {
-    log.verbose('PuppetService', 'callCancel(%s)', callId)
+    this.log.verbose('PuppetService', 'callCancel(%s)', callId)
 
     const request = new grpcPuppet.CallCancelRequest()
     request.setCallId(callId)
@@ -1319,7 +1319,7 @@ class PuppetService extends PUPPET.Puppet {
     callId: string,
     reason?: string,
   ): Promise<void> {
-    log.verbose('PuppetService', 'callHangup(%s, %s)', callId, reason)
+    this.log.verbose('PuppetService', 'callHangup(%s, %s)', callId, reason)
 
     const request = new grpcPuppet.CallHangupRequest()
     request.setCallId(callId)
@@ -1336,7 +1336,7 @@ class PuppetService extends PUPPET.Puppet {
   override async callMediaEndpoint (
     callId: string,
   ): Promise<PUPPET.payloads.CallMediaEndpoint> {
-    log.verbose('PuppetService', 'callMediaEndpoint(%s)', callId)
+    this.log.verbose('PuppetService', 'callMediaEndpoint(%s)', callId)
 
     const request = new grpcPuppet.CallMediaEndpointRequest()
     request.setCallId(callId)
@@ -1370,7 +1370,7 @@ class PuppetService extends PUPPET.Puppet {
   }
 
   override async callRawPayload (callId: string): Promise<grpcPuppet.CallPayloadResponse.AsObject> {
-    log.verbose('PuppetService', 'callRawPayload(%s)', callId)
+    this.log.verbose('PuppetService', 'callRawPayload(%s)', callId)
 
     const request = new grpcPuppet.CallPayloadRequest()
     request.setId(callId)
@@ -1384,6 +1384,10 @@ class PuppetService extends PUPPET.Puppet {
   }
 
   override async callRawPayloadParser (rawPayload: grpcPuppet.CallPayloadResponse.AsObject): Promise<PUPPET.payloads.Call> {
+    // Intentionally uses the module-level `log` instead of `this.log`: the
+    // matching unit spec invokes this parser via `prototype.call({}, raw)` and
+    // never binds a real PuppetService instance. Keep this `this`-free so that
+    // contract survives the pluggable-logger migration.
     log.verbose('PuppetService', 'callRawPayloadParser({id:%s})', rawPayload.id)
 
     const media = grpcCallTypeToPuppetMedia(rawPayload.media)
@@ -1416,7 +1420,7 @@ class PuppetService extends PUPPET.Puppet {
   override async messageChatHistory (
     messageId: string,
   ): Promise<PUPPET.payloads.ChatHistory[]> {
-    log.verbose('PuppetService', 'messageChatHistory(%s)', messageId)
+    this.log.verbose('PuppetService', 'messageChatHistory(%s)', messageId)
 
     const request = new grpcPuppet.MessageChatHistoryRequest()
     request.setId(messageId)
@@ -1435,7 +1439,7 @@ class PuppetService extends PUPPET.Puppet {
     conversationId     : string,
     miniProgramPayload : PUPPET.payloads.MiniProgram,
   ): Promise<void | string> {
-    log.verbose('PuppetService', 'messageSendMiniProgram(%s, "%s")', conversationId, JSON.stringify(miniProgramPayload))
+    this.log.verbose('PuppetService', 'messageSendMiniProgram(%s, "%s")', conversationId, JSON.stringify(miniProgramPayload))
 
     const request = new grpcPuppet.MessageSendMiniProgramRequest()
     request.setConversationId(conversationId)
@@ -1457,14 +1461,14 @@ class PuppetService extends PUPPET.Puppet {
      */
     request.setMiniProgramDeprecated(JSON.stringify(miniProgramPayload))
 
-    log.info('PuppetService', `messageSendMiniProgram(${conversationId}, ${miniProgramPayload.description}) about to call grpc`)
+    this.log.info('PuppetService', `messageSendMiniProgram(${conversationId}, ${miniProgramPayload.description}) about to call grpc`)
     const response = await util.promisify(
       this.grpcManager.client.messageSendMiniProgram
         .bind(this.grpcManager.client),
     )(request)
 
     const messageId = response.getId()
-    log.info('PuppetService', `messageSendMiniProgram(${conversationId}, ${miniProgramPayload.description}) grpc called, messageId: ${messageId}`)
+    this.log.info('PuppetService', `messageSendMiniProgram(${conversationId}, ${miniProgramPayload.description}) grpc called, messageId: ${messageId}`)
 
     if (messageId) {
       return messageId
@@ -1486,7 +1490,7 @@ class PuppetService extends PUPPET.Puppet {
     conversationId: string,
     locationPayload: PUPPET.payloads.Location,
   ): Promise<void | string> {
-    log.verbose('PuppetService', 'messageSendLocation(%s)', conversationId, JSON.stringify(locationPayload))
+    this.log.verbose('PuppetService', 'messageSendLocation(%s)', conversationId, JSON.stringify(locationPayload))
 
     const request = new grpcPuppet.MessageSendLocationRequest()
     request.setConversationId(conversationId)
@@ -1499,14 +1503,14 @@ class PuppetService extends PUPPET.Puppet {
     pbLocationPayload.setName(locationPayload.name)
     request.setLocation(pbLocationPayload)
 
-    log.info('PuppetService', `messageSendLocation(${conversationId}, ${locationPayload.name}) about to call grpc`)
+    this.log.info('PuppetService', `messageSendLocation(${conversationId}, ${locationPayload.name}) about to call grpc`)
     const response = await util.promisify(
       this.grpcManager.client.messageSendLocation
         .bind(this.grpcManager.client),
     )(request)
 
     const id = response.getId()
-    log.info('PuppetService', `messageSendMiniProgram(${conversationId}, ${locationPayload.name}) grpc called, messageId: ${id}`)
+    this.log.info('PuppetService', `messageSendMiniProgram(${conversationId}, ${locationPayload.name}) grpc called, messageId: ${id}`)
 
     if (id) {
       return id
@@ -1517,7 +1521,7 @@ class PuppetService extends PUPPET.Puppet {
     conversationId: string,
     channelPayload: PUPPET.payloads.Channel,
   ): Promise<void | string> {
-    log.verbose('PuppetService', 'messageSendChannel(%s, "%s")', conversationId, JSON.stringify(channelPayload))
+    this.log.verbose('PuppetService', 'messageSendChannel(%s, "%s")', conversationId, JSON.stringify(channelPayload))
 
     const request = new grpcPuppet.MessageSendChannelRequest()
     request.setConversationId(conversationId)
@@ -1526,14 +1530,14 @@ class PuppetService extends PUPPET.Puppet {
 
     request.setChannel(pbChannelPayload)
 
-    log.info('PuppetService', `messageSendChannel(${conversationId}, ${channelPayload.desc}) about to call grpc`)
+    this.log.info('PuppetService', `messageSendChannel(${conversationId}, ${channelPayload.desc}) about to call grpc`)
     const response = await util.promisify(
       this.grpcManager.client.messageSendChannel
         .bind(this.grpcManager.client),
     )(request)
 
     const messageId = response.getId()
-    log.info('PuppetService', `messageSendChannel(${conversationId}, ${channelPayload.desc}) grpc called, messageId: ${messageId}`)
+    this.log.info('PuppetService', `messageSendChannel(${conversationId}, ${channelPayload.desc}) grpc called, messageId: ${messageId}`)
 
     if (messageId) {
       return messageId
@@ -1544,7 +1548,7 @@ class PuppetService extends PUPPET.Puppet {
     conversationId: string,
     channelCardPayload: PUPPET.payloads.ChannelCard,
   ): Promise<void | string> {
-    log.verbose('PuppetService', 'messageSendChannelCard(%s, "%s")', conversationId, JSON.stringify(channelCardPayload))
+    this.log.verbose('PuppetService', 'messageSendChannelCard(%s, "%s")', conversationId, JSON.stringify(channelCardPayload))
 
     const request = new grpcPuppet.MessageSendChannelCardRequest()
     request.setConversationId(conversationId)
@@ -1553,14 +1557,14 @@ class PuppetService extends PUPPET.Puppet {
 
     request.setChannelCard(pbChannelCardPayload)
 
-    log.info('PuppetService', `messageSendChannelCard(${conversationId}, ${channelCardPayload.nickname}) about to call grpc`)
+    this.log.info('PuppetService', `messageSendChannelCard(${conversationId}, ${channelCardPayload.nickname}) about to call grpc`)
     const response = await util.promisify(
       this.grpcManager.client.messageSendChannelCard
         .bind(this.grpcManager.client),
     )(request)
 
     const messageId = response.getId()
-    log.info('PuppetService', `messageSendChannelCard(${conversationId}, ${channelCardPayload.nickname}) grpc called, messageId: ${messageId}`)
+    this.log.info('PuppetService', `messageSendChannelCard(${conversationId}, ${channelCardPayload.nickname}) grpc called, messageId: ${messageId}`)
 
     if (messageId) {
       return messageId
@@ -1570,7 +1574,7 @@ class PuppetService extends PUPPET.Puppet {
   override async messageRecall (
     messageId: string,
   ): Promise<boolean> {
-    log.verbose('PuppetService', 'messageRecall(%s)', messageId)
+    this.log.verbose('PuppetService', 'messageRecall(%s)', messageId)
 
     const request = new grpcPuppet.MessageRecallRequest()
     request.setId(messageId)
@@ -1584,7 +1588,7 @@ class PuppetService extends PUPPET.Puppet {
   }
 
   override async messageFile (id: string): Promise<FileBoxInterface> {
-    log.verbose('PuppetService', 'messageFile(%s)', id)
+    this.log.verbose('PuppetService', 'messageFile(%s)', id)
 
     const request = new grpcPuppet.MessageFileRequest()
     request.setId(id)
@@ -1602,7 +1606,7 @@ class PuppetService extends PUPPET.Puppet {
   }
 
   override async messageVoice (id: string): Promise<FileBoxInterface> {
-    log.verbose('PuppetService', 'messageVoice(%s)', id)
+    this.log.verbose('PuppetService', 'messageVoice(%s)', id)
 
     const request = new grpcPuppet.MessageVoiceRequest()
     request.setId(id)
@@ -1620,7 +1624,7 @@ class PuppetService extends PUPPET.Puppet {
   }
 
   override async messageVoiceText (id: string): Promise<PUPPET.payloads.VoiceText> {
-    log.verbose('PuppetService', 'messageVoiceText(%s)', id)
+    this.log.verbose('PuppetService', 'messageVoiceText(%s)', id)
 
     const request = new grpcPuppet.MessageVoiceTextRequest()
     request.setId(id)
@@ -1636,7 +1640,7 @@ class PuppetService extends PUPPET.Puppet {
   }
 
   override async messagePreview (id: string): Promise<FileBoxInterface | undefined> {
-    log.verbose('PuppetService', 'messagePreview(%s)', id)
+    this.log.verbose('PuppetService', 'messagePreview(%s)', id)
 
     const request = new grpcPuppet.MessagePreviewRequest()
     request.setId(id)
@@ -1656,7 +1660,7 @@ class PuppetService extends PUPPET.Puppet {
     conversationId: string,
     messageIds: string | string[],
   ): Promise<string | void> {
-    log.verbose('PuppetService', 'messageForward(%s, %s)', conversationId, messageIds)
+    this.log.verbose('PuppetService', 'messageForward(%s, %s)', conversationId, messageIds)
 
     const request = new grpcPuppet.MessageForwardRequest()
     request.setConversationId(conversationId)
@@ -1669,14 +1673,14 @@ class PuppetService extends PUPPET.Puppet {
       request.setMessageId(messageIds)
     }
 
-    log.info('PuppetService', `messageForward(${conversationId}, ${messageIds}) about to call grpc`)
+    this.log.info('PuppetService', `messageForward(${conversationId}, ${messageIds}) about to call grpc`)
     const response = await util.promisify(
       this.grpcManager.client.messageForward
         .bind(this.grpcManager.client),
     )(request)
 
     const forwardedMessageId = response.getId()
-    log.info('PuppetService', `messageForward(${conversationId}, ${messageIds}) grpc called, messageId: ${forwardedMessageId}`)
+    this.log.info('PuppetService', `messageForward(${conversationId}, ${messageIds}) grpc called, messageId: ${forwardedMessageId}`)
 
     if (forwardedMessageId) {
       return forwardedMessageId
@@ -1695,11 +1699,11 @@ class PuppetService extends PUPPET.Puppet {
   }
 
   override async messageRawPayload (id: string): Promise<PUPPET.payloads.Message> {
-    log.verbose('PuppetService', 'messageRawPayload(%s)', id)
+    this.log.verbose('PuppetService', 'messageRawPayload(%s)', id)
 
     // const cachedPayload = await this.payloadStore.message?.get(id)
     // if (cachedPayload) {
-    //   log.silly('PuppetService', 'messageRawPayload(%s) cache HIT', id)
+    //   this.log.silly('PuppetService', 'messageRawPayload(%s) cache HIT', id)
     //   return cachedPayload
     // }
 
@@ -1754,19 +1758,19 @@ class PuppetService extends PUPPET.Puppet {
           break
         }
         default:
-          log.warn('PuppetService', `unknown text content type ${type}`)
+          this.log.warn('PuppetService', `unknown text content type ${type}`)
       }
       payload.textContent?.push(contentData)
     }
 
-    // log.silly('PuppetService', 'messageRawPayload(%s) cache SET', id)
+    // this.log.silly('PuppetService', 'messageRawPayload(%s) cache SET', id)
     // await this.payloadStore.message?.set(id, payload)
 
     return payload
   }
 
   override async messageRawPayloadParser (payload: PUPPET.payloads.Message): Promise<PUPPET.payloads.Message> {
-    // log.silly('PuppetService', 'messagePayload({id:%s})', payload.id)
+    // this.log.silly('PuppetService', 'messagePayload({id:%s})', payload.id)
     // passthrough
     return payload
   }
@@ -1776,7 +1780,7 @@ class PuppetService extends PUPPET.Puppet {
     text           : string,
     options?       : PUPPET.types.MessageSendTextOptions,
   ): Promise<void | string> {
-    log.verbose('PuppetService', 'messageSend(%s, %s)', conversationId, text)
+    this.log.verbose('PuppetService', 'messageSend(%s, %s)', conversationId, text)
     let mentionIdList
     let quoteId
     if (Array.isArray(options)) {
@@ -1795,14 +1799,14 @@ class PuppetService extends PUPPET.Puppet {
       request.setQuoteId(quoteId)
     }
 
-    log.info('PuppetService', `messageSend(${conversationId}, ${text}) about to call grpc`)
+    this.log.info('PuppetService', `messageSend(${conversationId}, ${text}) about to call grpc`)
     const response = await util.promisify(
       this.grpcManager.client.messageSendText
         .bind(this.grpcManager.client),
     )(request)
 
     const messageId = response.getId()
-    log.info('PuppetService', `messageSend(${conversationId}, ${text}) grpc called, messageId: ${messageId}`)
+    this.log.info('PuppetService', `messageSend(${conversationId}, ${text}) grpc called, messageId: ${messageId}`)
 
     if (messageId) {
       return messageId
@@ -1825,7 +1829,7 @@ class PuppetService extends PUPPET.Puppet {
     text            : string,
     batchTaskId?    : string,
   ): Promise<MessageBatchSendResponse> {
-    log.verbose('PuppetService', 'messageBatchSendText(%s)', conversationIds.join(','))
+    this.log.verbose('PuppetService', 'messageBatchSendText(%s)', conversationIds.join(','))
 
     const request = new grpcPuppet.MessageBatchSendTextRequest()
     request.setConversationIdsList(conversationIds)
@@ -1847,7 +1851,7 @@ class PuppetService extends PUPPET.Puppet {
     fileBox         : FileBoxInterface,
     batchTaskId?    : string,
   ): Promise<MessageBatchSendResponse> {
-    log.verbose('PuppetService', 'messageBatchSendFile(%s)', conversationIds.join(','))
+    this.log.verbose('PuppetService', 'messageBatchSendFile(%s)', conversationIds.join(','))
 
     const request = new grpcPuppet.MessageBatchSendFileRequest()
     request.setConversationIdsList(conversationIds)
@@ -1869,7 +1873,7 @@ class PuppetService extends PUPPET.Puppet {
     messageIds      : string | string[],
     batchTaskId?    : string,
   ): Promise<MessageBatchSendResponse> {
-    log.verbose('PuppetService', 'messageBatchForward(%s, %s)', conversationIds.join(','), messageIds)
+    this.log.verbose('PuppetService', 'messageBatchForward(%s, %s)', conversationIds.join(','), messageIds)
 
     const request = new grpcPuppet.MessageBatchForwardRequest()
     request.setConversationIdsList(conversationIds)
@@ -1898,7 +1902,7 @@ class PuppetService extends PUPPET.Puppet {
     contactId       : string,
     batchTaskId?    : string,
   ): Promise<MessageBatchSendResponse> {
-    log.verbose('PuppetService', 'messageBatchSendContact(%s, %s)', conversationIds.join(','), contactId)
+    this.log.verbose('PuppetService', 'messageBatchSendContact(%s, %s)', conversationIds.join(','), contactId)
 
     const request = new grpcPuppet.MessageBatchSendContactRequest()
     request.setConversationIdsList(conversationIds)
@@ -1920,7 +1924,7 @@ class PuppetService extends PUPPET.Puppet {
     urlLinkPayload  : PUPPET.payloads.UrlLink,
     batchTaskId?    : string,
   ): Promise<MessageBatchSendResponse> {
-    log.verbose('PuppetService', 'messageBatchSendUrl(%s)', conversationIds.join(','))
+    this.log.verbose('PuppetService', 'messageBatchSendUrl(%s)', conversationIds.join(','))
 
     const request = new grpcPuppet.MessageBatchSendUrlRequest()
     request.setConversationIdsList(conversationIds)
@@ -1942,7 +1946,7 @@ class PuppetService extends PUPPET.Puppet {
     miniProgramPayload  : PUPPET.payloads.MiniProgram,
     batchTaskId?        : string,
   ): Promise<MessageBatchSendResponse> {
-    log.verbose('PuppetService', 'messageBatchSendMiniProgram(%s)', conversationIds.join(','))
+    this.log.verbose('PuppetService', 'messageBatchSendMiniProgram(%s)', conversationIds.join(','))
 
     const request = new grpcPuppet.MessageBatchSendMiniProgramRequest()
     request.setConversationIdsList(conversationIds)
@@ -1964,7 +1968,7 @@ class PuppetService extends PUPPET.Puppet {
     locationPayload  : PUPPET.payloads.Location,
     batchTaskId?     : string,
   ): Promise<MessageBatchSendResponse> {
-    log.verbose('PuppetService', 'messageBatchSendLocation(%s)', conversationIds.join(','))
+    this.log.verbose('PuppetService', 'messageBatchSendLocation(%s)', conversationIds.join(','))
 
     const request = new grpcPuppet.MessageBatchSendLocationRequest()
     request.setConversationIdsList(conversationIds)
@@ -1986,7 +1990,7 @@ class PuppetService extends PUPPET.Puppet {
     channelPayload  : PUPPET.payloads.Channel,
     batchTaskId?    : string,
   ): Promise<MessageBatchSendResponse> {
-    log.verbose('PuppetService', 'messageBatchSendChannel(%s)', conversationIds.join(','))
+    this.log.verbose('PuppetService', 'messageBatchSendChannel(%s)', conversationIds.join(','))
 
     const request = new grpcPuppet.MessageBatchSendChannelRequest()
     request.setConversationIdsList(conversationIds)
@@ -2008,7 +2012,7 @@ class PuppetService extends PUPPET.Puppet {
     channelCardPayload  : PUPPET.payloads.ChannelCard,
     batchTaskId?        : string,
   ): Promise<MessageBatchSendResponse> {
-    log.verbose('PuppetService', 'messageBatchSendChannelCard(%s)', conversationIds.join(','))
+    this.log.verbose('PuppetService', 'messageBatchSendChannelCard(%s)', conversationIds.join(','))
 
     const request = new grpcPuppet.MessageBatchSendChannelCardRequest()
     request.setConversationIdsList(conversationIds)
@@ -2029,7 +2033,7 @@ class PuppetService extends PUPPET.Puppet {
     conversationId : string,
     fileBox        : FileBoxInterface,
   ): Promise<void | string> {
-    log.verbose('PuppetService', 'messageSendFile(%s, %s)', conversationId, fileBox)
+    this.log.verbose('PuppetService', 'messageSendFile(%s, %s)', conversationId, fileBox)
 
     const request = new grpcPuppet.MessageSendFileRequest()
     request.setConversationId(conversationId)
@@ -2037,14 +2041,14 @@ class PuppetService extends PUPPET.Puppet {
     const serializedFileBox = await this.serializeFileBox(fileBox)
     request.setFileBox(serializedFileBox)
 
-    log.info('PuppetService', `messageSendFile(${conversationId}, ${fileBox}) about to call grpc`)
+    this.log.info('PuppetService', `messageSendFile(${conversationId}, ${fileBox}) about to call grpc`)
     const response = await util.promisify(
       this.grpcManager.client.messageSendFile
         .bind(this.grpcManager.client),
     )(request)
 
     const messageId = response.getId()
-    log.info('PuppetService', `messageSendFile(${conversationId}, ${fileBox}) grpc called, messageId: ${messageId}`)
+    this.log.info('PuppetService', `messageSendFile(${conversationId}, ${fileBox}) grpc called, messageId: ${messageId}`)
 
     if (messageId) {
       return messageId
@@ -2063,20 +2067,20 @@ class PuppetService extends PUPPET.Puppet {
     conversationId  : string,
     contactId       : string,
   ): Promise<void | string> {
-    log.verbose('PuppetService', 'messageSend("%s", %s)', conversationId, contactId)
+    this.log.verbose('PuppetService', 'messageSend("%s", %s)', conversationId, contactId)
 
     const request = new grpcPuppet.MessageSendContactRequest()
     request.setConversationId(conversationId)
     request.setContactId(contactId)
 
-    log.info('PuppetService', `messageSendContact(${conversationId}, ${contactId}) about to call grpc`)
+    this.log.info('PuppetService', `messageSendContact(${conversationId}, ${contactId}) about to call grpc`)
     const response = await util.promisify(
       this.grpcManager.client.messageSendContact
         .bind(this.grpcManager.client),
     )(request)
 
     const messageId = response.getId()
-    log.info('PuppetService', `messageSendContact(${conversationId}, ${contactId}) grpc called, messageId: ${messageId}`)
+    this.log.info('PuppetService', `messageSendContact(${conversationId}, ${contactId}) grpc called, messageId: ${messageId}`)
 
     if (messageId) {
       return messageId
@@ -2098,7 +2102,7 @@ class PuppetService extends PUPPET.Puppet {
     conversationId: string,
     urlLinkPayload: PUPPET.payloads.UrlLink,
   ): Promise<void | string> {
-    log.verbose('PuppetService', 'messageSendUrl("%s", %s)', conversationId, JSON.stringify(urlLinkPayload))
+    this.log.verbose('PuppetService', 'messageSendUrl("%s", %s)', conversationId, JSON.stringify(urlLinkPayload))
 
     const request = new grpcPuppet.MessageSendUrlRequest()
     request.setConversationId(conversationId)
@@ -2113,14 +2117,14 @@ class PuppetService extends PUPPET.Puppet {
     // Deprecated: will be removed after Dec 31, 2022
     request.setUrlLinkDeprecated(JSON.stringify(urlLinkPayload))
 
-    log.info('PuppetService', `messageSendUrl(${conversationId}, ${urlLinkPayload}) about to call grpc`)
+    this.log.info('PuppetService', `messageSendUrl(${conversationId}, ${urlLinkPayload}) about to call grpc`)
     const response = await util.promisify(
       this.grpcManager.client.messageSendUrl
         .bind(this.grpcManager.client),
     )(request)
 
     const messageId = response.getId()
-    log.info('PuppetService', `messageSendUrl(${conversationId}, ${urlLinkPayload}) grpc called, messageId: ${messageId}`)
+    this.log.info('PuppetService', `messageSendUrl(${conversationId}, ${urlLinkPayload}) grpc called, messageId: ${messageId}`)
 
     if (messageId) {
       return messageId
@@ -2142,21 +2146,21 @@ class PuppetService extends PUPPET.Puppet {
     conversationId: string,
     postPayload: PUPPET.payloads.PostClient,
   ): Promise<void | string> {
-    log.verbose('PuppetService', 'messageSendPost("%s", %s)', conversationId, JSON.stringify(postPayload))
+    this.log.verbose('PuppetService', 'messageSendPost("%s", %s)', conversationId, JSON.stringify(postPayload))
 
     const request = new grpcPuppet.MessageSendPostRequest()
     const post = await postPayloadToPb(grpcPuppet, postPayload, this.serializeFileBox.bind(this))
     request.setContent(post)
     request.setConversationId(conversationId)
 
-    log.info('PuppetService', `messageSendPost(${conversationId}, ${postPayload}) about to call grpc`)
+    this.log.info('PuppetService', `messageSendPost(${conversationId}, ${postPayload}) about to call grpc`)
     const response = await util.promisify(
       this.grpcManager.client.messageSendPost
         .bind(this.grpcManager.client),
     )(request)
 
     const messageId = response.getId()
-    log.info('PuppetService', `messageSendPost(${conversationId}, ${postPayload}) grpc called, messageId: ${messageId}`)
+    this.log.info('PuppetService', `messageSendPost(${conversationId}, ${postPayload}) grpc called, messageId: ${messageId}`)
 
     if (messageId) {
       return messageId
@@ -2164,7 +2168,7 @@ class PuppetService extends PUPPET.Puppet {
   }
 
   override async messageUrl (messageId: string): Promise<PUPPET.payloads.UrlLink> {
-    log.verbose('PuppetService', 'messageUrl(%s)', messageId)
+    this.log.verbose('PuppetService', 'messageUrl(%s)', messageId)
 
     const request = new grpcPuppet.MessageUrlRequest()
     request.setId(messageId)
@@ -2190,7 +2194,7 @@ class PuppetService extends PUPPET.Puppet {
   }
 
   override async getMessageBroadcastTarget (): Promise<MessageBroadcastTargets> {
-    log.verbose('PuppetService', 'getMessageBroadcastTarget()')
+    this.log.verbose('PuppetService', 'getMessageBroadcastTarget()')
 
     const request = new grpcPuppet.GetMessageBroadcastTargetRequest()
 
@@ -2205,7 +2209,7 @@ class PuppetService extends PUPPET.Puppet {
   }
 
   override async createMessageBroadcast (targets: string[], content: PUPPET.payloads.Post): Promise<string | void> {
-    log.verbose('PuppetService', 'createMessageBroadcast()')
+    this.log.verbose('PuppetService', 'createMessageBroadcast()')
 
     if (!PUPPET.payloads.isPostClient(content)) {
       throw new Error('can only create broadcast with client post')
@@ -2224,7 +2228,7 @@ class PuppetService extends PUPPET.Puppet {
   }
 
   override async getMessageBroadcastStatus (id: string): Promise<{ status: PUPPET.types.BroadcastStatus; detail: { contactId?: string | undefined; roomId?: string | undefined; status: PUPPET.types.BroadcastTargetStatus }[] }> {
-    log.verbose('PuppetService', 'getMessageBroadcastStatus()')
+    this.log.verbose('PuppetService', 'getMessageBroadcastStatus()')
 
     const request = new grpcPuppet.GetMessageBroadcastStatusRequest()
     request.setId(id)
@@ -2264,11 +2268,11 @@ class PuppetService extends PUPPET.Puppet {
   override async roomRawPayload (
     id: string,
   ): Promise<PUPPET.payloads.Room> {
-    log.verbose('PuppetService', 'roomRawPayload(%s)', id)
+    this.log.verbose('PuppetService', 'roomRawPayload(%s)', id)
 
     const cachedPayload = await this._payloadStore.room?.get(id)
     if (cachedPayload) {
-      log.silly('PuppetService', 'roomRawPayload(%s) cache HIT', id)
+      this.log.silly('PuppetService', 'roomRawPayload(%s) cache HIT', id)
       return cachedPayload
     }
 
@@ -2299,19 +2303,19 @@ class PuppetService extends PUPPET.Puppet {
     }
 
     await this._payloadStore.room?.set(id, payload)
-    log.silly('PuppetService', 'roomRawPayload(%s) cache SET', id)
+    this.log.silly('PuppetService', 'roomRawPayload(%s) cache SET', id)
 
     return payload
   }
 
   override async roomRawPayloadParser (payload: PUPPET.payloads.Room): Promise<PUPPET.payloads.Room> {
-    // log.silly('PuppetService', 'roomRawPayloadParser({id:%s})', payload.id)
+    // this.log.silly('PuppetService', 'roomRawPayloadParser({id:%s})', payload.id)
     // passthrough
     return payload
   }
 
   override async batchRoomRawPayload (roomIdList: string[]): Promise<Map<string, PUPPET.payloads.Room>> {
-    log.verbose('PuppetService', 'batchRoomRawPayload(%s)', roomIdList)
+    this.log.verbose('PuppetService', 'batchRoomRawPayload(%s)', roomIdList)
 
     const result = new Map<string, PUPPET.payloads.Room>()
     const roomIdSet = new Set<string>(roomIdList)
@@ -2358,7 +2362,7 @@ class PuppetService extends PUPPET.Puppet {
           await this._payloadStore.room?.set(roomId, puppetPayload)
         }
       } catch (e) {
-        log.error('PuppetService', 'batchRoomRawPayload(%s, %s) error: %s, use one by one method', roomIdList, needGetSet, e)
+        this.log.error('PuppetService', 'batchRoomRawPayload(%s, %s) error: %s, use one by one method', roomIdList, needGetSet, e)
         for (const roomId of needGetSet) {
           const payload = await this.roomRawPayload(roomId)
           result.set(roomId, payload)
@@ -2369,7 +2373,7 @@ class PuppetService extends PUPPET.Puppet {
   }
 
   override async roomList (): Promise<string[]> {
-    log.verbose('PuppetService', 'roomList()')
+    this.log.verbose('PuppetService', 'roomList()')
 
     const response = await util.promisify(
       this.grpcManager.client.roomList
@@ -2383,7 +2387,7 @@ class PuppetService extends PUPPET.Puppet {
     roomId    : string,
     contactIds : string | string[],
   ): Promise<void> {
-    log.verbose('PuppetService', 'roomDel(%s, %s)', roomId, contactIds)
+    this.log.verbose('PuppetService', 'roomDel(%s, %s)', roomId, contactIds)
 
     const request = new grpcPuppet.RoomDelRequest()
     request.setId(roomId)
@@ -2403,7 +2407,7 @@ class PuppetService extends PUPPET.Puppet {
   }
 
   override async roomDelV2 (roomId: string, contactIds: string[]): Promise<{ successList: string[]; failList: string[]; failReasonList: string[] }> {
-    log.verbose('PuppetService', 'roomDelV2(%s, %s)', roomId, contactIds)
+    this.log.verbose('PuppetService', 'roomDelV2(%s, %s)', roomId, contactIds)
 
     const request = new grpcPuppet.RoomDelV2Request()
     request.setId(roomId)
@@ -2422,7 +2426,7 @@ class PuppetService extends PUPPET.Puppet {
   }
 
   override async roomAvatar (roomId: string): Promise<FileBoxInterface> {
-    log.verbose('PuppetService', 'roomAvatar(%s)', roomId)
+    this.log.verbose('PuppetService', 'roomAvatar(%s)', roomId)
 
     const request = new grpcPuppet.RoomAvatarRequest()
     request.setId(roomId)
@@ -2442,7 +2446,7 @@ class PuppetService extends PUPPET.Puppet {
     inviteOnly : boolean,
     quoteIds   : string[],
   ): Promise<void> {
-    log.verbose('PuppetService', 'roomAdd(%s, %s)', roomId, contactId)
+    this.log.verbose('PuppetService', 'roomAdd(%s, %s)', roomId, contactId)
 
     const request = new grpcPuppet.RoomAddRequest()
     request.setId(roomId)
@@ -2465,7 +2469,7 @@ class PuppetService extends PUPPET.Puppet {
     inviteOnly: boolean,
     quoteIds: string[],
   ): Promise<{ successList: string[]; failList: string[]; failReasonList: string[]; }> {
-    log.verbose('PuppetService', 'roomAddV2(%s, %s)', roomId, contactIds)
+    this.log.verbose('PuppetService', 'roomAddV2(%s, %s)', roomId, contactIds)
 
     const request = new grpcPuppet.RoomAddV2Request()
     request.setId(roomId)
@@ -2492,7 +2496,7 @@ class PuppetService extends PUPPET.Puppet {
     roomId: string,
     topic?: string,
   ): Promise<void | string> {
-    log.verbose('PuppetService', 'roomTopic(%s, %s)', roomId, topic)
+    this.log.verbose('PuppetService', 'roomTopic(%s, %s)', roomId, topic)
 
     /**
      * Get
@@ -2544,7 +2548,7 @@ class PuppetService extends PUPPET.Puppet {
   }
 
   override async roomRemark (roomId: string, remark: string): Promise<void> {
-    log.verbose('PuppetService', 'roomRemark(%s)', roomId)
+    this.log.verbose('PuppetService', 'roomRemark(%s)', roomId)
 
     const request = new grpcPuppet.RoomRemarkRequest()
     request.setId(roomId)
@@ -2560,7 +2564,7 @@ class PuppetService extends PUPPET.Puppet {
     contactIdList : string[],
     topic         : string,
   ): Promise<string> {
-    log.verbose('PuppetService', 'roomCreate(%s, %s)', contactIdList, topic)
+    this.log.verbose('PuppetService', 'roomCreate(%s, %s)', contactIdList, topic)
 
     const request = new grpcPuppet.RoomCreateRequest()
     request.setContactIdsList(contactIdList)
@@ -2575,7 +2579,7 @@ class PuppetService extends PUPPET.Puppet {
   }
 
   override async roomQuit (roomId: string): Promise<void> {
-    log.verbose('PuppetService', 'roomQuit(%s)', roomId)
+    this.log.verbose('PuppetService', 'roomQuit(%s)', roomId)
 
     const request = new grpcPuppet.RoomQuitRequest()
     request.setId(roomId)
@@ -2587,7 +2591,7 @@ class PuppetService extends PUPPET.Puppet {
   }
 
   override async roomQRCode (roomId: string): Promise<string> {
-    log.verbose('PuppetService', 'roomQRCode(%s)', roomId)
+    this.log.verbose('PuppetService', 'roomQRCode(%s)', roomId)
 
     const request = new grpcPuppet.RoomQRCodeRequest()
     request.setId(roomId)
@@ -2601,7 +2605,7 @@ class PuppetService extends PUPPET.Puppet {
   }
 
   override async roomParseDynamicQRCode (url: string): Promise<PUPPET.types.RoomParseDynamicQRCode> {
-    log.verbose('PuppetService', 'roomParseDynamicQRCode(%s)', url)
+    this.log.verbose('PuppetService', 'roomParseDynamicQRCode(%s)', url)
 
     const request = new grpcPuppet.RoomParseDynamicQRCodeRequest()
     request.setUrl(url)
@@ -2619,7 +2623,7 @@ class PuppetService extends PUPPET.Puppet {
   }
 
   override async roomMemberList (roomId: string) : Promise<string[]> {
-    log.verbose('PuppetService', 'roomMemberList(%s)', roomId)
+    this.log.verbose('PuppetService', 'roomMemberList(%s)', roomId)
 
     const request = new grpcPuppet.RoomMemberListRequest()
     request.setId(roomId)
@@ -2633,13 +2637,13 @@ class PuppetService extends PUPPET.Puppet {
   }
 
   override async roomMemberRawPayload (roomId: string, contactId: string): Promise<PUPPET.payloads.RoomMember>  {
-    log.verbose('PuppetService', 'roomMemberRawPayload(%s, %s)', roomId, contactId)
+    this.log.verbose('PuppetService', 'roomMemberRawPayload(%s, %s)', roomId, contactId)
 
     const cachedPayload           = await this._payloadStore.roomMember?.get(roomId)
     const cachedRoomMemberPayload = cachedPayload && cachedPayload[contactId]
 
     if (cachedRoomMemberPayload) {
-      log.silly('PuppetService', 'roomMemberRawPayload(%s, %s) cache HIT', roomId, contactId)
+      this.log.silly('PuppetService', 'roomMemberRawPayload(%s, %s) cache HIT', roomId, contactId)
       return cachedRoomMemberPayload
     }
 
@@ -2667,19 +2671,19 @@ class PuppetService extends PUPPET.Puppet {
       ...cachedPayload,
       [contactId]: payload,
     })
-    log.silly('PuppetService', 'roomMemberRawPayload(%s, %s) cache SET', roomId, contactId)
+    this.log.silly('PuppetService', 'roomMemberRawPayload(%s, %s) cache SET', roomId, contactId)
 
     return payload
   }
 
   override async roomMemberRawPayloadParser (payload: PUPPET.payloads.RoomMember): Promise<PUPPET.payloads.RoomMember>  {
-    // log.silly('PuppetService', 'roomMemberRawPayloadParser({id:%s})', payload.id)
+    // this.log.silly('PuppetService', 'roomMemberRawPayloadParser({id:%s})', payload.id)
     // passthrough
     return payload
   }
 
   override async batchRoomMemberRawPayload (roomId: string, contactIdList: string[]): Promise<Map<string, PUPPET.payloads.RoomMember>> {
-    log.verbose('PuppetService', 'batchRoomMemberRawPayload(%s, %s)', roomId, contactIdList)
+    this.log.verbose('PuppetService', 'batchRoomMemberRawPayload(%s, %s)', roomId, contactIdList)
 
     const result = new Map<string, PUPPET.payloads.RoomMember>()
     const contactIdSet = new Set<string>(contactIdList)
@@ -2718,7 +2722,7 @@ class PuppetService extends PUPPET.Puppet {
         }
         await this._payloadStore.roomMember?.set(roomId, cachedPayload)
       } catch (e) {
-        log.error('PuppetService', 'batchRoomMemberRawPayload(%s, %s) error: %s, use one by one method', roomId, needGetSet, e)
+        this.log.error('PuppetService', 'batchRoomMemberRawPayload(%s, %s) error: %s, use one by one method', roomId, needGetSet, e)
         for (const contactId of needGetSet) {
           const payload = await this.roomMemberRawPayload(roomId, contactId)
           result.set(contactId, payload)
@@ -2732,7 +2736,7 @@ class PuppetService extends PUPPET.Puppet {
   override async roomAnnounce (roomId: string, text: string)  : Promise<void>
 
   override async roomAnnounce (roomId: string, text?: string) : Promise<void | string> {
-    log.verbose('PuppetService', 'roomAnnounce(%s%s)',
+    this.log.verbose('PuppetService', 'roomAnnounce(%s%s)',
       roomId,
       typeof text === 'undefined'
         ? ''
@@ -2792,7 +2796,7 @@ class PuppetService extends PUPPET.Puppet {
   override async roomInvitationAccept (
     roomInvitationId: string,
   ): Promise<void> {
-    log.verbose('PuppetService', 'roomInvitationAccept(%s)', roomInvitationId)
+    this.log.verbose('PuppetService', 'roomInvitationAccept(%s)', roomInvitationId)
 
     const request = new grpcPuppet.RoomInvitationAcceptRequest()
     request.setId(roomInvitationId)
@@ -2806,7 +2810,7 @@ class PuppetService extends PUPPET.Puppet {
   override async roomInvitationAcceptByQRCode (
     qrcode: string,
   ): Promise<PUPPET.types.RoomInvitationAcceptByQRCode> {
-    log.verbose('PuppetService', 'roomInvitationAcceptByQRCode(%s)', qrcode)
+    this.log.verbose('PuppetService', 'roomInvitationAcceptByQRCode(%s)', qrcode)
 
     const request = new grpcPuppet.RoomInvitationAcceptByQRCodeRequest()
     request.setQrcode(qrcode)
@@ -2825,7 +2829,7 @@ class PuppetService extends PUPPET.Puppet {
   override async roomInvitationRawPayload (
     id: string,
   ): Promise<PUPPET.payloads.RoomInvitation> {
-    log.verbose('PuppetService', 'roomInvitationRawPayload(%s)', id)
+    this.log.verbose('PuppetService', 'roomInvitationRawPayload(%s)', id)
 
     const request = new grpcPuppet.RoomInvitationPayloadRequest()
     request.setId(id)
@@ -2870,13 +2874,13 @@ class PuppetService extends PUPPET.Puppet {
   }
 
   override async roomInvitationRawPayloadParser (payload: PUPPET.payloads.RoomInvitation): Promise<PUPPET.payloads.RoomInvitation> {
-    // log.silly('PuppetService', 'roomInvitationRawPayloadParser({id:%s})', payload.id)
+    // this.log.silly('PuppetService', 'roomInvitationRawPayloadParser({id:%s})', payload.id)
     // passthrough
     return payload
   }
 
   override async roomPermission (roomId: string, permission?: Partial<PUPPET.types.RoomPermission>): Promise<void | Partial<PUPPET.types.RoomPermission>> {
-    log.verbose('PuppetService', 'roomPermission(%s, %s)', roomId, JSON.stringify(permission))
+    this.log.verbose('PuppetService', 'roomPermission(%s, %s)', roomId, JSON.stringify(permission))
 
     const request = new grpcPuppet.RoomPermissionRequest()
     request.setId(roomId)
@@ -2911,7 +2915,7 @@ class PuppetService extends PUPPET.Puppet {
   }
 
   override async roomOwnerTransfer (roomId: string, contactId: string): Promise<void> {
-    log.verbose('PuppetService', 'roomOwnerTransfer(%s, %s)', roomId, contactId)
+    this.log.verbose('PuppetService', 'roomOwnerTransfer(%s, %s)', roomId, contactId)
 
     const request = new grpcPuppet.RoomOwnerTransferRequest()
     request.setId(roomId)
@@ -2927,7 +2931,7 @@ class PuppetService extends PUPPET.Puppet {
     roomId     : string,
     contactIdList  : string[],
   ): Promise<void> {
-    log.verbose('PuppetService', 'roomAddAdmins(%s, %s)', roomId, contactIdList)
+    this.log.verbose('PuppetService', 'roomAddAdmins(%s, %s)', roomId, contactIdList)
 
     const request = new grpcPuppet.RoomAdminsRequest()
     request.setId(roomId)
@@ -2943,7 +2947,7 @@ class PuppetService extends PUPPET.Puppet {
     roomId    : string,
     contactIdList : string[],
   ): Promise<void> {
-    log.verbose('PuppetService', 'roomDelAdmins(%s, %s)', roomId, contactIdList)
+    this.log.verbose('PuppetService', 'roomDelAdmins(%s, %s)', roomId, contactIdList)
 
     const request = new grpcPuppet.RoomAdminsRequest()
     request.setId(roomId)
@@ -2956,7 +2960,7 @@ class PuppetService extends PUPPET.Puppet {
   }
 
   override async roomDismiss (roomId: string): Promise<void> {
-    log.verbose('PuppetService', 'roomDelAdmins(%s)', roomId)
+    this.log.verbose('PuppetService', 'roomDelAdmins(%s)', roomId)
 
     const request = new grpcPuppet.RoomDismissRequest()
     request.setId(roomId)
@@ -2976,7 +2980,7 @@ class PuppetService extends PUPPET.Puppet {
     phone: string,
     type?: Contact,
   ): Promise<string | null> {
-    log.verbose('PuppetService', 'friendshipSearchPhone(%s)', phone)
+    this.log.verbose('PuppetService', 'friendshipSearchPhone(%s)', phone)
 
     const request = new grpcPuppet.FriendshipSearchPhoneRequest()
     request.setPhone(phone)
@@ -3012,7 +3016,7 @@ class PuppetService extends PUPPET.Puppet {
     handle: string,
     type?: Contact,
   ): Promise<string | null> {
-    log.verbose('PuppetService', 'friendshipSearchHandle(%s)', handle)
+    this.log.verbose('PuppetService', 'friendshipSearchHandle(%s)', handle)
 
     const request = new grpcPuppet.FriendshipSearchHandleRequest()
     /**
@@ -3048,7 +3052,7 @@ class PuppetService extends PUPPET.Puppet {
   }
 
   override async friendshipRawPayload (id: string): Promise<PUPPET.payloads.Friendship> {
-    log.verbose('PuppetService', 'friendshipRawPayload(%s)', id)
+    this.log.verbose('PuppetService', 'friendshipRawPayload(%s)', id)
 
     const request = new grpcPuppet.FriendshipPayloadRequest()
     request.setId(id)
@@ -3072,7 +3076,7 @@ class PuppetService extends PUPPET.Puppet {
   }
 
   override async friendshipRawPayloadParser (payload: PUPPET.payloads.Friendship) : Promise<PUPPET.payloads.Friendship> {
-    // log.silly('PuppetService', 'friendshipRawPayloadParser({id:%s})', payload.id)
+    // this.log.silly('PuppetService', 'friendshipRawPayloadParser({id:%s})', payload.id)
     // passthrough
     return payload
   }
@@ -3081,7 +3085,7 @@ class PuppetService extends PUPPET.Puppet {
     contactId : string,
     options   : PUPPET.types.FriendshipAddOptions,
   ): Promise<void> {
-    log.verbose('PuppetService', 'friendshipAdd(%s, %s)', contactId, JSON.stringify(options))
+    this.log.verbose('PuppetService', 'friendshipAdd(%s, %s)', contactId, JSON.stringify(options))
 
     const request = new grpcPuppet.FriendshipAddRequest()
     request.setContactId(contactId)
@@ -3117,7 +3121,7 @@ class PuppetService extends PUPPET.Puppet {
   override async friendshipAccept (
     friendshipId : string,
   ): Promise<void> {
-    log.verbose('PuppetService', 'friendshipAccept(%s)', friendshipId)
+    this.log.verbose('PuppetService', 'friendshipAccept(%s)', friendshipId)
 
     const request = new grpcPuppet.FriendshipAcceptRequest()
     request.setId(friendshipId)
@@ -3138,7 +3142,7 @@ class PuppetService extends PUPPET.Puppet {
     tagIds: string[],
     contactIds: string[],
   ): Promise<void> {
-    log.verbose('PuppetService', 'tagContactTagAdd(%s, %s)', tagIds, contactIds)
+    this.log.verbose('PuppetService', 'tagContactTagAdd(%s, %s)', tagIds, contactIds)
 
     const request = new grpcPuppet.TagContactTagAddRequest()
 
@@ -3155,7 +3159,7 @@ class PuppetService extends PUPPET.Puppet {
     tagIds: string[],
     contactIds: string[],
   ): Promise<void> {
-    log.verbose('PuppetService', 'tagContactTagRemove(%s, %s)', tagIds, contactIds)
+    this.log.verbose('PuppetService', 'tagContactTagRemove(%s, %s)', tagIds, contactIds)
 
     const request = new grpcPuppet.TagContactTagRemoveRequest()
 
@@ -3171,7 +3175,7 @@ class PuppetService extends PUPPET.Puppet {
   override async tagGroupAdd (
     tagGroupName: string,
   ): Promise<string | void> {
-    log.verbose('PuppetService', 'tagGroupAdd(%s)', tagGroupName)
+    this.log.verbose('PuppetService', 'tagGroupAdd(%s)', tagGroupName)
 
     const request = new grpcPuppet.TagGroupAddRequest()
 
@@ -3190,7 +3194,7 @@ class PuppetService extends PUPPET.Puppet {
   override async tagGroupDelete (
     tagGroupId: string,
   ): Promise<void> {
-    log.verbose('PuppetService', 'tagGroupDelete(%s)', tagGroupId)
+    this.log.verbose('PuppetService', 'tagGroupDelete(%s)', tagGroupId)
 
     const request = new grpcPuppet.TagGroupDeleteRequest()
 
@@ -3207,7 +3211,7 @@ class PuppetService extends PUPPET.Puppet {
     tagNameList: string[],
     tagGroupId?: string,
   ): Promise<PUPPET.types.TagInfo[] | void> {
-    log.verbose('PuppetService', 'tagTagAdd(%s, %s)', tagNameList, tagGroupId)
+    this.log.verbose('PuppetService', 'tagTagAdd(%s, %s)', tagNameList, tagGroupId)
 
     const request = new grpcPuppet.TagTagAddRequest()
 
@@ -3232,7 +3236,7 @@ class PuppetService extends PUPPET.Puppet {
   override async tagTagDelete (
     tagIdList: string[],
   ): Promise<void> {
-    log.verbose('PuppetService', 'tagTagDelete(%s)', tagIdList)
+    this.log.verbose('PuppetService', 'tagTagDelete(%s)', tagIdList)
 
     const request = new grpcPuppet.TagTagDeleteRequest()
     request.setTagIdList(tagIdList)
@@ -3247,7 +3251,7 @@ class PuppetService extends PUPPET.Puppet {
   override async tagTagModify (
     tagNewInfoList: PUPPET.types.TagInfo[],
   ): Promise<PUPPET.types.TagInfo[] | void> {
-    log.verbose('PuppetService', 'tagTagModify(%o)', tagNewInfoList)
+    this.log.verbose('PuppetService', 'tagTagModify(%o)', tagNewInfoList)
 
     const request = new grpcPuppet.TagTagModifyRequest()
     const newInfoList = tagNewInfoList.map(i => {
@@ -3272,7 +3276,7 @@ class PuppetService extends PUPPET.Puppet {
   }
 
   override async tagGroupList (): Promise<string[]> {
-    log.verbose('PuppetService', 'tagGroupList()')
+    this.log.verbose('PuppetService', 'tagGroupList()')
 
     const request = new grpcPuppet.TagGroupListRequest()
 
@@ -3288,7 +3292,7 @@ class PuppetService extends PUPPET.Puppet {
   override async tagGroupTagList (
     tagGroupId?: string,
   ): Promise<string[]> {
-    log.verbose('PuppetService', 'tagGroupTagList(%s)', tagGroupId)
+    this.log.verbose('PuppetService', 'tagGroupTagList(%s)', tagGroupId)
 
     const request = new grpcPuppet.TagGroupTagListRequest()
     if (typeof tagGroupId !== 'undefined') {
@@ -3306,7 +3310,7 @@ class PuppetService extends PUPPET.Puppet {
 
   override async tagTagList (
   ): Promise<string[]> {
-    log.verbose('PuppetService', 'tagTagList()')
+    this.log.verbose('PuppetService', 'tagTagList()')
 
     const request = new grpcPuppet.TagTagListRequest()
 
@@ -3322,7 +3326,7 @@ class PuppetService extends PUPPET.Puppet {
   override async tagContactTagList (
     contactId: string,
   ): Promise<string[]> {
-    log.verbose('PuppetService', 'tagContactTagList(%s)', contactId)
+    this.log.verbose('PuppetService', 'tagContactTagList(%s)', contactId)
 
     const request = new grpcPuppet.TagContactTagListRequest()
     request.setContactId(contactId)
@@ -3339,7 +3343,7 @@ class PuppetService extends PUPPET.Puppet {
   override async tagTagContactList (
     tagId: string,
   ): Promise<string[]> {
-    log.verbose('PuppetService', 'tagTagContactList(%s)', tagId)
+    this.log.verbose('PuppetService', 'tagTagContactList(%s)', tagId)
 
     const request = new grpcPuppet.TagTagContactListRequest()
     request.setTagId(tagId)
@@ -3354,11 +3358,11 @@ class PuppetService extends PUPPET.Puppet {
   }
 
   override async tagGroupPayloadPuppet (id: string): Promise<PUPPET.payloads.TagGroup> {
-    log.verbose('PuppetService', 'tagGroupPayload(%s)', id)
+    this.log.verbose('PuppetService', 'tagGroupPayload(%s)', id)
 
     const cachedPayload = await this._payloadStore.tagGroup?.get(id)
     if (cachedPayload) {
-      log.silly('PuppetService', 'tagGroupPayload(%s) cache HIT', id)
+      this.log.silly('PuppetService', 'tagGroupPayload(%s) cache HIT', id)
       return cachedPayload
     }
 
@@ -3382,17 +3386,17 @@ class PuppetService extends PUPPET.Puppet {
     }
 
     await this._payloadStore.tagGroup?.set(id, payload)
-    log.silly('PuppetService', 'tagGroupPayloadPuppet(%s) cache SET', id)
+    this.log.silly('PuppetService', 'tagGroupPayloadPuppet(%s) cache SET', id)
 
     return payload
   }
 
   override async tagPayloadPuppet (tagId: string): Promise<PUPPET.payloads.Tag> {
-    log.verbose('PuppetService', 'tagPayloadPuppet(%s)', tagId)
+    this.log.verbose('PuppetService', 'tagPayloadPuppet(%s)', tagId)
 
     const cachedPayload = await this._payloadStore.tag?.get(tagId)
     if (cachedPayload) {
-      log.silly('PuppetService', 'tagPayloadPuppet(%s) cache HIT', tagId)
+      this.log.silly('PuppetService', 'tagPayloadPuppet(%s) cache HIT', tagId)
       return cachedPayload
     }
 
@@ -3417,7 +3421,7 @@ class PuppetService extends PUPPET.Puppet {
     }
 
     await this._payloadStore.tag?.set(tagId, payload)
-    log.silly('PuppetService', 'tagPayloadPuppet(%s) cache SET', tagId)
+    this.log.silly('PuppetService', 'tagPayloadPuppet(%s) cache SET', tagId)
 
     return payload
   }
@@ -3429,7 +3433,7 @@ class PuppetService extends PUPPET.Puppet {
    */
 
   override async postPublish (payload: PUPPET.payloads.Post): Promise<void | string> {
-    log.verbose('PuppetService', 'postPublish(%s)', payload)
+    this.log.verbose('PuppetService', 'postPublish(%s)', payload)
 
     if (!PUPPET.payloads.isPostClient(payload)) {
       throw new Error('can only publish client post now')
@@ -3449,7 +3453,7 @@ class PuppetService extends PUPPET.Puppet {
   }
 
   override async postUnpublish (id: string): Promise<void> {
-    log.verbose('PuppetService', 'postUnpublish(%s)', id)
+    this.log.verbose('PuppetService', 'postUnpublish(%s)', id)
 
     const request = new grpcPuppet.MomentUnpublishRequest()
     request.setMomentId(id)
@@ -3460,7 +3464,7 @@ class PuppetService extends PUPPET.Puppet {
   }
 
   override async momentSignature (text?: string): Promise<void | string> {
-    log.verbose('PuppetService', 'momentSignature(%s)', text)
+    this.log.verbose('PuppetService', 'momentSignature(%s)', text)
 
     const request = new grpcPuppet.MomentSignatureRequest()
     if (text) {
@@ -3478,7 +3482,7 @@ class PuppetService extends PUPPET.Puppet {
   }
 
   override async momentCoverage (cover?: FileBoxInterface | undefined): Promise<void | FileBoxInterface> {
-    log.verbose('PuppetService', 'momentCoverage(%s)', JSON.stringify(cover))
+    this.log.verbose('PuppetService', 'momentCoverage(%s)', JSON.stringify(cover))
 
     const request = new grpcPuppet.MomentCoverageRequest()
     if (cover) {
@@ -3498,7 +3502,7 @@ class PuppetService extends PUPPET.Puppet {
   }
 
   override async postPayloadSayable (postId: string, sayableId: string): Promise<PUPPET.payloads.Sayable> {
-    log.verbose('PuppetService', 'postPayloadSayable(%s, %s)', postId, sayableId)
+    this.log.verbose('PuppetService', 'postPayloadSayable(%s, %s)', postId, sayableId)
 
     const request = new grpcPuppet.PostPayloadSayableRequest()
     request.setPostId(postId)
@@ -3556,7 +3560,7 @@ class PuppetService extends PUPPET.Puppet {
   }
 
   override async postRawPayload (id: string): Promise<PUPPET.payloads.Post> {
-    log.verbose('PuppetService', 'postRawPayload(%s)', id)
+    this.log.verbose('PuppetService', 'postRawPayload(%s)', id)
 
     const request = new grpcPuppet.PostPayloadRequest()
     request.setPostId(id)
@@ -3607,13 +3611,13 @@ class PuppetService extends PUPPET.Puppet {
   }
 
   override async postRawPayloadParser (payload: PUPPET.payloads.Post): Promise<PUPPET.payloads.Post> {
-    // log.silly('PuppetService', 'postRawPayloadParser({id:%s})', payload.id)
+    // this.log.silly('PuppetService', 'postRawPayloadParser({id:%s})', payload.id)
     // passthrough
     return payload
   }
 
   override async tap (postId: string, type?: PUPPET.types.Tap, tap = true): Promise<boolean | void> {
-    log.verbose('PuppetService', 'tap(%s, %s, %s)', postId, type, tap)
+    this.log.verbose('PuppetService', 'tap(%s, %s, %s)', postId, type, tap)
 
     const request = new grpcPuppet.PostTapRequest()
     request.setPostId(postId)
@@ -3631,7 +3635,7 @@ class PuppetService extends PUPPET.Puppet {
   }
 
   override async momentVisibleList (): Promise<string[]> {
-    log.verbose('PuppetService', 'momentVisibleList()')
+    this.log.verbose('PuppetService', 'momentVisibleList()')
 
     const request = new grpcPuppet.MomentVisibleListRequest()
 
@@ -3648,7 +3652,7 @@ class PuppetService extends PUPPET.Puppet {
     contactIds: string[],
     serviceProviderId?: string,
   ): Promise<PUPPET.types.ContactIdExternalUserIdPair[]> {
-    log.verbose('PuppetService', 'getContactExternalUserId(%s, %s)', JSON.stringify(contactIds), serviceProviderId)
+    this.log.verbose('PuppetService', 'getContactExternalUserId(%s, %s)', JSON.stringify(contactIds), serviceProviderId)
 
     const request = new grpcPuppet.GetContactExternalUserIdRequest()
 
@@ -3673,7 +3677,7 @@ class PuppetService extends PUPPET.Puppet {
   }
 
   override async getRoomAntiSpamStrategyList (): Promise<PUPPET.types.RoomAntiSpamStrategy[]> {
-    log.verbose('PuppetService', 'getRoomAntiSpamStrategyList()')
+    this.log.verbose('PuppetService', 'getRoomAntiSpamStrategyList()')
 
     const request = new grpcPuppet.GetRoomAntiSpamStrategyListRequest()
 
@@ -3695,7 +3699,7 @@ class PuppetService extends PUPPET.Puppet {
   }
 
   override async getRoomAntiSpamStrategyEffectRoomList (strategyId: string): Promise<string[]> {
-    log.verbose('PuppetService', 'getRoomAntiSpamStrategyEffectRoomList(%s)', strategyId)
+    this.log.verbose('PuppetService', 'getRoomAntiSpamStrategyEffectRoomList(%s)', strategyId)
 
     const request = new grpcPuppet.GetRoomAntiSpamStrategyEffectRoomListRequest()
     request.setStrategyId(strategyId)
@@ -3710,7 +3714,7 @@ class PuppetService extends PUPPET.Puppet {
   }
 
   override async applyRoomAntiSpamStrategy (strategyId: string, roomIds: string[], active: boolean): Promise<void> {
-    log.verbose('PuppetService', 'applyRoomAntiSpamStrategy(%s, %s, %s)', strategyId, roomIds, active)
+    this.log.verbose('PuppetService', 'applyRoomAntiSpamStrategy(%s, %s, %s)', strategyId, roomIds, active)
 
     const request = new grpcPuppet.ApplyRoomAntiSpamStrategyRequest()
     request.setStrategyId(strategyId)
@@ -3723,7 +3727,7 @@ class PuppetService extends PUPPET.Puppet {
   }
 
   override async getCorpMessageInterceptionStrategies (): Promise<PUPPET.types.CorpMessageInterceptionStrategy[]> {
-    log.verbose('PuppetService', 'getCorpMessageInterceptionStrategies()')
+    this.log.verbose('PuppetService', 'getCorpMessageInterceptionStrategies()')
 
     const request = new grpcPuppet.GetCorpMessageInterceptionStrategiesRequest()
 
@@ -3767,17 +3771,17 @@ class PuppetService extends PUPPET.Puppet {
   private reconnectIndicator: BooleanIndicator
   override async reset (): Promise<void> {
     if (!this._grpcManager) {
-      log.warn('PuppetService', 'grpc manager not constructed, perform regular reset')
+      this.log.warn('PuppetService', 'grpc manager not constructed, perform regular reset')
       return super.reset()
     }
 
     if (!this.isLoggedIn) {
-      log.warn('PuppetService', 'puppet not logged in, perform regular reset')
+      this.log.warn('PuppetService', 'puppet not logged in, perform regular reset')
       return super.reset()
     }
 
     if (this.reconnectIndicator.value()) {
-      log.warn('PuppetService', 'already trying to reconnect, pass this one')
+      this.log.warn('PuppetService', 'already trying to reconnect, pass this one')
       return
     }
 
@@ -3831,12 +3835,12 @@ class PuppetService extends PUPPET.Puppet {
         break
       } catch (e) {
         if (Date.now() - startTime < timeoutMilliseconds) {
-          log.warn('failed to start stream, will try again in 15 seconds')
+          this.log.warn('failed to start stream, will try again in 15 seconds')
           await new Promise(resolve => {
             setTimeout(resolve, 5000)
           })
         } else {
-          log.warn('failed to start stream and reaches timeout, will perform regular reset')
+          this.log.warn('failed to start stream and reaches timeout, will perform regular reset')
           this.reconnectIndicator.value(false)
           return super.reset()
         }
@@ -3854,7 +3858,7 @@ class PuppetService extends PUPPET.Puppet {
           this.grpcManager.off('data', onLogin)
         })
     } catch (e) {
-      log.warn('PuppetService', 'waiting for event reset login error, will perform regular reset')
+      this.log.warn('PuppetService', 'waiting for event reset login error, will perform regular reset')
       return super.reset()
     }
     try {
@@ -3864,7 +3868,7 @@ class PuppetService extends PUPPET.Puppet {
           this.grpcManager.off('data', onReady)
         })
     } catch (e) {
-      log.warn('PuppetService', 'waiting for event reset ready error, will do nothing')
+      this.log.warn('PuppetService', 'waiting for event reset ready error, will do nothing')
     }
   }
 
@@ -3879,7 +3883,7 @@ class PuppetService extends PUPPET.Puppet {
     const lastEventTimestamp = await this._payloadStore.miscellaneous?.get('lastEventTimestamp')
     let lastEventSeq = await this._payloadStore.miscellaneous?.get('lastEventSeq')
     if ((Date.now() - Number(lastEventTimestamp || 0)) > this.timeoutMilliseconds) {
-      log.warn(`last event was ${(Date.now() - Number(lastEventTimestamp || 0)) / 1000} seconds ago, will not request event cache`)
+      this.log.warn(`last event was ${(Date.now() - Number(lastEventTimestamp || 0)) / 1000} seconds ago, will not request event cache`)
       lastEventSeq = undefined
     }
     const accountId = await this._payloadStore.miscellaneous?.get('accountId')

--- a/src/utils/pb-payload-helper.ts
+++ b/src/utils/pb-payload-helper.ts
@@ -284,6 +284,8 @@ export const callRecordPbToPayload = (callRecordPb: puppet.CallRecordPayload) =>
     type: callRecordPb.getType(),
     status: callRecordPb.getStatus(),
   }
+  const callId = callRecordPb.getCallId()
+  if (callId) { callRecordPayload.callId = callId }
   return callRecordPayload
 }
 
@@ -294,6 +296,7 @@ export const callRecordPayloadToPb = (grpcPuppet: grpcPuppet, callRecordPayload:
   pbCallRecordPayload.setLength(callRecordPayload.length)
   pbCallRecordPayload.setType(callRecordPayload.type)
   pbCallRecordPayload.setStatus(callRecordPayload.status)
+  if (callRecordPayload.callId) { pbCallRecordPayload.setCallId(callRecordPayload.callId) }
 
   return pbCallRecordPayload
 }


### PR DESCRIPTION
## Summary

Adopt wechaty-puppet 1.0.147's `PuppetOptions.logger` mechanism. Since `PuppetService` extends `PUPPET.Puppet`, `this.log` is naturally inherited from the base — every instance method routes through it and picks up the caller-supplied logger (if any).

## Motivation

Downstream of wechaty-puppet's pluggable logger PR, so bot hosts can attach botId to every log line inside the puppet layer.

## Changes

- 216 instance-method call sites migrated `log.xxx` → `this.log.xxx`
- `callRawPayloadParser` deliberately kept module-level — the spec calls it via `prototype.call({})` and requires the parser to not touch `this`; comment locked in
- Server-side (`PuppetServer` / `EventStreamManager` / `HealthServiceImpl`) untouched: they don't inherit `Puppet`, and server-side logger injection is a separate story
- Peer and dev range for `@juzi/wechaty-puppet` lifted to `^1.0.147` — the `this.log ??= log` runtime fallback was removed, so consumers must resolve a puppet that owns `Puppet#log`

## Compatibility

Zero-break provided the peer resolves to `@juzi/wechaty-puppet@^1.0.147`. Older puppet versions do not own `Puppet#log`, and this PR intentionally raises the peer floor to prevent a mismatched install.

## Release order

This PR bumps the `@juzi/wechaty-puppet` peer range to `^1.0.147`, which corresponds to the sibling wechaty-puppet PR (juzibot/wechaty-puppet feat/pluggable-logger). Publish order must be:

1. `@juzi/wechaty-puppet@1.0.147` to npm
2. **Then** `@juzi/wechaty-puppet-service@1.0.123`

Merging this PR before wechaty-puppet 1.0.147 ships is fine — the constraint is on `npm publish`, not on git.

## Verified

- `npm test`: 24/24 tap spec pass (after linked to local wechaty-puppet 1.0.147)
- Lint (es/ts/md): clean
- tsc build against linked wechaty-puppet: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)