### PR TITLE
fix: guard FlashStore write-backs against dirty landing mid raw-fetch

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -82,6 +82,9 @@ jobs:
       - name: Install latest npm
         run: curl -qL https://www.npmjs.com/install.sh | sh
 
+      - name: Allow npm lifecycle scripts (npm >= 12 skips dependency scripts by default; node-jq needs its postinstall to fetch the jq binary for pkg-jq)
+        run: npm config set dangerously-allow-all-scripts true
+
       - name: Install Dependencies
         run: npm install
 

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -79,11 +79,13 @@ jobs:
           cache: npm
           cache-dependency-path: package.json
 
-      - name: Install latest npm
-        run: curl -qL https://www.npmjs.com/install.sh | sh
-
-      - name: Allow npm lifecycle scripts (npm >= 12 skips dependency scripts by default; node-jq needs its postinstall to fetch the jq binary for pkg-jq)
-        run: npm config set dangerously-allow-all-scripts true
+      # Pin npm 11: npm 12 skips dependency lifecycle scripts by default
+      # (node-jq never fetches its jq binary, breaking pkg-jq) and its
+      # in-place upgrade over the bundled npm corrupts `npm publish`
+      # (Cannot find module 'sigstore'). npm 11 behaves like the runs
+      # that published successfully before 2026-07.
+      - name: Install npm 11
+        run: npm install -g npm@11
 
       - name: Install Dependencies
         run: npm install

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@juzi/wechaty-puppet-service",
-  "version": "1.0.124",
+  "version": "1.0.125",
   "description": "Puppet Service for Wechaty",
   "type": "module",
   "exports": {
@@ -51,7 +51,7 @@
     "@chatie/eslint-config": "^1.0.4",
     "@chatie/semver": "^0.4.7",
     "@chatie/tsconfig": "^4.6.3",
-    "@juzi/wechaty-puppet": "^1.0.148",
+    "@juzi/wechaty-puppet": "^1.0.149",
     "@juzi/wechaty-puppet-mock": "^1.0.1",
     "@swc/core": "1.3.39",
     "@types/google-protobuf": "^3.15.5",
@@ -71,7 +71,7 @@
     "why-is-node-running": "^2.2.1"
   },
   "peerDependencies": {
-    "@juzi/wechaty-puppet": "^1.0.148"
+    "@juzi/wechaty-puppet": "^1.0.149"
   },
   "dependencies": {
     "@juzi/wechaty-grpc": "^1.0.106",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@chatie/eslint-config": "^1.0.4",
     "@chatie/semver": "^0.4.7",
     "@chatie/tsconfig": "^4.6.3",
-    "@juzi/wechaty-puppet": "^1.0.149",
+    "@juzi/wechaty-puppet": "^1.0.150",
     "@juzi/wechaty-puppet-mock": "^1.0.1",
     "@swc/core": "1.3.39",
     "@types/google-protobuf": "^3.15.5",
@@ -71,7 +71,7 @@
     "why-is-node-running": "^2.2.1"
   },
   "peerDependencies": {
-    "@juzi/wechaty-puppet": "^1.0.149"
+    "@juzi/wechaty-puppet": "^1.0.150"
   },
   "dependencies": {
     "@juzi/wechaty-grpc": "^1.0.106",

--- a/src/client/puppet-service.ts
+++ b/src/client/puppet-service.ts
@@ -385,6 +385,35 @@ class PuppetService extends PUPPET.Puppet {
         break
       case grpcPuppet.EventType.EVENT_TYPE_DIRTY: {
         const dirtyPayload = JSON.parse(payload) as PUPPET.payloads.EventDirty
+        /**
+         * Bump the generation counter *before* awaiting fastDirty so the
+         * whole fastDirty window is covered: any raw fetch that started
+         * before this dirty and resolves while fastDirty is deleting the
+         * FlashStore row must be judged stale by `isFreshWrite` and skip
+         * its write-back -- otherwise it re-poisons the row we just
+         * cleared and the value only refreshes after a *second* dirty.
+         *
+         * Upstream cache-mixin.onDirty bumps the same (type, id) again
+         * after `emit('dirty')` below; double-bumping is harmless because
+         * the counter only moves forward and `isFreshWrite` compares by
+         * equality.
+         */
+        this.cache.bumpGen(dirtyPayload.payloadType, dirtyPayload.payloadId)
+        /**
+         * A compound RoomMember dirty (`${roomId}${SEP}${memberId}`) must
+         * also bump the bare roomId key: roomMember write-backs are
+         * row-level read-modify-writes keyed by roomId, so a single-member
+         * dirty has to move that key too or an in-flight roomMember fetch
+         * could still write the whole row back stale.
+         */
+        if (dirtyPayload.payloadType === PUPPET.types.Dirty.RoomMember
+            && dirtyPayload.payloadId.includes(PUPPET.STRING_SPLITTER)
+        ) {
+          const [ roomId ] = dirtyPayload.payloadId.split(PUPPET.STRING_SPLITTER)
+          if (roomId) {
+            this.cache.bumpGen(PUPPET.types.Dirty.RoomMember, roomId)
+          }
+        }
         await this.fastDirty(dirtyPayload)
         this.emit('dirty', dirtyPayload)
         break
@@ -855,6 +884,10 @@ class PuppetService extends PUPPET.Puppet {
       return cachedPayload
     }
 
+    // Snapshot the gen before the raw fetch so a dirty that lands while
+    // the gRPC round-trip is in flight makes the write-back below stale.
+    const gen = this.cache.snapshotGen(PUPPET.types.Dirty.Contact, id)
+
     const request = new grpcPuppet.ContactPayloadRequest()
     request.setId(id)
 
@@ -897,8 +930,12 @@ class PuppetService extends PUPPET.Puppet {
       aka           : response.getAka(),
     }
 
-    await this._payloadStore.contact?.set(id, payload)
-    this.log.silly('PuppetService', 'contactRawPayload(%s) cache SET', id)
+    if (this.cache.isFreshWrite(PUPPET.types.Dirty.Contact, id, gen)) {
+      await this._payloadStore.contact?.set(id, payload)
+      this.log.silly('PuppetService', 'contactRawPayload(%s) cache SET', id)
+    } else {
+      this.log.silly('PuppetService', 'contactRawPayload(%s) cache SET skipped: dirty landed during raw fetch', id)
+    }
 
     return payload
   }
@@ -926,6 +963,14 @@ class PuppetService extends PUPPET.Puppet {
 
     if (needGetSet.size > 0) {
       try {
+        // Snapshot each id's gen before the batch fetch; write-backs below
+        // are validated per id so a dirty on one contact mid-flight only
+        // skips that contact's stale write, not the whole batch.
+        const genSnap = new Map<string, number>()
+        for (const contactId of needGetSet) {
+          genSnap.set(contactId, this.cache.snapshotGen(PUPPET.types.Dirty.Contact, contactId))
+        }
+
         const request = new grpcPuppet.BatchContactPayloadRequest()
         request.setIdsList(Array.from(needGetSet))
 
@@ -939,7 +984,11 @@ class PuppetService extends PUPPET.Puppet {
           const contactId = payload.getId()
           const puppetPayload = contactPbToPayload(payload)
           result.set(contactId, puppetPayload)
-          await this._payloadStore.contact?.set(contactId, puppetPayload)
+          if (this.cache.isFreshWrite(PUPPET.types.Dirty.Contact, contactId, genSnap.get(contactId) ?? 0)) {
+            await this._payloadStore.contact?.set(contactId, puppetPayload)
+          } else {
+            this.log.silly('PuppetService', 'batchContactRawPayload(%s) cache SET skipped: dirty landed during raw fetch', contactId)
+          }
         }
       } catch (e) {
         this.log.error('PuppetService', 'batchContactRawPayload(%s, %s) error: %s, use one by one method', contactIdList, needGetSet, e)
@@ -2303,6 +2352,10 @@ class PuppetService extends PUPPET.Puppet {
       return cachedPayload
     }
 
+    // Snapshot the gen before the raw fetch so a dirty that lands while
+    // the gRPC round-trip is in flight makes the write-back below stale.
+    const gen = this.cache.snapshotGen(PUPPET.types.Dirty.Room, id)
+
     const request = new grpcPuppet.RoomPayloadRequest()
     request.setId(id)
 
@@ -2329,8 +2382,12 @@ class PuppetService extends PUPPET.Puppet {
       payload.createTime = millisecondsFromTimestamp(createTime)
     }
 
-    await this._payloadStore.room?.set(id, payload)
-    this.log.silly('PuppetService', 'roomRawPayload(%s) cache SET', id)
+    if (this.cache.isFreshWrite(PUPPET.types.Dirty.Room, id, gen)) {
+      await this._payloadStore.room?.set(id, payload)
+      this.log.silly('PuppetService', 'roomRawPayload(%s) cache SET', id)
+    } else {
+      this.log.silly('PuppetService', 'roomRawPayload(%s) cache SET skipped: dirty landed during raw fetch', id)
+    }
 
     return payload
   }
@@ -2358,6 +2415,14 @@ class PuppetService extends PUPPET.Puppet {
 
     if (needGetSet.size > 0) {
       try {
+        // Snapshot each id's gen before the batch fetch; write-backs below
+        // are validated per id so a dirty on one room mid-flight only skips
+        // that room's stale write, not the whole batch.
+        const genSnap = new Map<string, number>()
+        for (const roomId of needGetSet) {
+          genSnap.set(roomId, this.cache.snapshotGen(PUPPET.types.Dirty.Room, roomId))
+        }
+
         const request = new grpcPuppet.BatchRoomPayloadRequest()
         request.setIdsList(Array.from(needGetSet))
 
@@ -2386,7 +2451,11 @@ class PuppetService extends PUPPET.Puppet {
             puppetPayload.createTime = millisecondsFromTimestamp(createTime)
           }
           result.set(roomId, puppetPayload)
-          await this._payloadStore.room?.set(roomId, puppetPayload)
+          if (this.cache.isFreshWrite(PUPPET.types.Dirty.Room, roomId, genSnap.get(roomId) ?? 0)) {
+            await this._payloadStore.room?.set(roomId, puppetPayload)
+          } else {
+            this.log.silly('PuppetService', 'batchRoomRawPayload(%s) cache SET skipped: dirty landed during raw fetch', roomId)
+          }
         }
       } catch (e) {
         this.log.error('PuppetService', 'batchRoomRawPayload(%s, %s) error: %s, use one by one method', roomIdList, needGetSet, e)
@@ -2666,6 +2735,13 @@ class PuppetService extends PUPPET.Puppet {
   override async roomMemberRawPayload (roomId: string, contactId: string): Promise<PUPPET.payloads.RoomMember>  {
     this.log.verbose('PuppetService', 'roomMemberRawPayload(%s, %s)', roomId, contactId)
 
+    // Row-level read-modify-write: the write-back merges the fetched
+    // member into the existing row, so snapshot the room-level gen before
+    // even reading the row. A room-level dirty (bare roomId, or the
+    // room-level bump a compound RoomMember dirty triggers) that lands
+    // anywhere in this window then skips the merge write-back.
+    const roomGen = this.cache.snapshotGen(PUPPET.types.Dirty.RoomMember, roomId)
+
     const cachedPayload           = await this._payloadStore.roomMember?.get(roomId)
     const cachedRoomMemberPayload = cachedPayload && cachedPayload[contactId]
 
@@ -2694,11 +2770,15 @@ class PuppetService extends PUPPET.Puppet {
       joinTime      : response.getJoinTime(),
     }
 
-    await this._payloadStore.roomMember?.set(roomId, {
-      ...cachedPayload,
-      [contactId]: payload,
-    })
-    this.log.silly('PuppetService', 'roomMemberRawPayload(%s, %s) cache SET', roomId, contactId)
+    if (this.cache.isFreshWrite(PUPPET.types.Dirty.RoomMember, roomId, roomGen)) {
+      await this._payloadStore.roomMember?.set(roomId, {
+        ...cachedPayload,
+        [contactId]: payload,
+      })
+      this.log.silly('PuppetService', 'roomMemberRawPayload(%s, %s) cache SET', roomId, contactId)
+    } else {
+      this.log.silly('PuppetService', 'roomMemberRawPayload(%s, %s) cache SET skipped: dirty landed during raw fetch', roomId, contactId)
+    }
 
     return payload
   }
@@ -2715,6 +2795,10 @@ class PuppetService extends PUPPET.Puppet {
     const result = new Map<string, PUPPET.payloads.RoomMember>()
     const contactIdSet = new Set<string>(contactIdList)
     let needGetSet = new Set<string>()
+    // Row-level read-modify-write keyed by roomId: snapshot the room-level
+    // gen before reading the row so a dirty landing anywhere in the window
+    // skips the merged write-back.
+    const roomGen = this.cache.snapshotGen(PUPPET.types.Dirty.RoomMember, roomId)
     const cachedPayload = await this._payloadStore.roomMember?.get(roomId) || {}
     if (Object.keys(cachedPayload).length > 0) {
       for (const contactId of contactIdSet) {
@@ -2747,7 +2831,11 @@ class PuppetService extends PUPPET.Puppet {
           result.set(contactId, puppetPayload)
           cachedPayload[contactId] = puppetPayload
         }
-        await this._payloadStore.roomMember?.set(roomId, cachedPayload)
+        if (this.cache.isFreshWrite(PUPPET.types.Dirty.RoomMember, roomId, roomGen)) {
+          await this._payloadStore.roomMember?.set(roomId, cachedPayload)
+        } else {
+          this.log.silly('PuppetService', 'batchRoomMemberRawPayload(%s) cache SET skipped: dirty landed during raw fetch', roomId)
+        }
       } catch (e) {
         this.log.error('PuppetService', 'batchRoomMemberRawPayload(%s, %s) error: %s, use one by one method', roomId, needGetSet, e)
         for (const contactId of needGetSet) {
@@ -3393,6 +3481,10 @@ class PuppetService extends PUPPET.Puppet {
       return cachedPayload
     }
 
+    // Snapshot the gen before the raw fetch so a dirty that lands while
+    // the gRPC round-trip is in flight makes the write-back below stale.
+    const gen = this.cache.snapshotGen(PUPPET.types.Dirty.TagGroup, id)
+
     const request = new grpcPuppet.TagGroupPayloadRequest()
     request.setGroupId(id)
 
@@ -3412,8 +3504,12 @@ class PuppetService extends PUPPET.Puppet {
       type: grpcPayload.getType(),
     }
 
-    await this._payloadStore.tagGroup?.set(id, payload)
-    this.log.silly('PuppetService', 'tagGroupPayloadPuppet(%s) cache SET', id)
+    if (this.cache.isFreshWrite(PUPPET.types.Dirty.TagGroup, id, gen)) {
+      await this._payloadStore.tagGroup?.set(id, payload)
+      this.log.silly('PuppetService', 'tagGroupPayloadPuppet(%s) cache SET', id)
+    } else {
+      this.log.silly('PuppetService', 'tagGroupPayloadPuppet(%s) cache SET skipped: dirty landed during raw fetch', id)
+    }
 
     return payload
   }
@@ -3426,6 +3522,10 @@ class PuppetService extends PUPPET.Puppet {
       this.log.silly('PuppetService', 'tagPayloadPuppet(%s) cache HIT', tagId)
       return cachedPayload
     }
+
+    // Snapshot the gen before the raw fetch so a dirty that lands while
+    // the gRPC round-trip is in flight makes the write-back below stale.
+    const gen = this.cache.snapshotGen(PUPPET.types.Dirty.Tag, tagId)
 
     const request = new grpcPuppet.TagPayloadRequest()
     request.setTagId(tagId)
@@ -3447,8 +3547,12 @@ class PuppetService extends PUPPET.Puppet {
       type: grpcPayload.getType(),
     }
 
-    await this._payloadStore.tag?.set(tagId, payload)
-    this.log.silly('PuppetService', 'tagPayloadPuppet(%s) cache SET', tagId)
+    if (this.cache.isFreshWrite(PUPPET.types.Dirty.Tag, tagId, gen)) {
+      await this._payloadStore.tag?.set(tagId, payload)
+      this.log.silly('PuppetService', 'tagPayloadPuppet(%s) cache SET', tagId)
+    } else {
+      this.log.silly('PuppetService', 'tagPayloadPuppet(%s) cache SET skipped: dirty landed during raw fetch', tagId)
+    }
 
     return payload
   }

--- a/tests/dirty-gen-guard.spec.ts
+++ b/tests/dirty-gen-guard.spec.ts
@@ -1,0 +1,227 @@
+#!/usr/bin/env -S node --no-warnings --loader ts-node/esm
+/**
+ * Regression tests for the FlashStore write-back generation guard.
+ *
+ * `_payloadStore` (FlashStore, on disk) is a cache layer independent of
+ * the puppet-side LRU. Before this fix it had no protection against the
+ * "dirty lands during a raw fetch" race:
+ *
+ *   1. A raw fetch (e.g. `contactRawPayload`) starts a gRPC round-trip.
+ *   2. An EVENT_TYPE_DIRTY arrives; `fastDirty` deletes the FlashStore row.
+ *   3. The in-flight fetch resolves and writes the *pre-dirty* payload
+ *      back into the FlashStore -- re-poisoning the row that was just
+ *      cleared. The value then only refreshes after a *second* dirty.
+ *
+ * The fix snapshots a per-(type, id) generation counter before the raw
+ * fetch and re-checks it with `isFreshWrite` before every FlashStore
+ * write-back; the EVENT_TYPE_DIRTY handler bumps that counter before it
+ * even awaits `fastDirty`, so the whole delete window is covered.
+ */
+import { test } from 'tstest'
+import os from 'os'
+import path from 'path'
+import fs from 'fs'
+
+import * as PUPPET from '@juzi/wechaty-puppet'
+import { puppet as grpcPuppet } from '@juzi/wechaty-grpc'
+
+import { PuppetService } from '../src/mod.js'
+
+const makePuppet = async () => {
+  const token = `puppet_service_test_${Date.now()}_${Math.floor(Math.random() * 1e6)}`
+  const puppet = new PuppetService({ token }) as any
+  const accountId = 'acct-test'
+  await puppet._payloadStore.start(accountId)
+  return { puppet, token }
+}
+
+const cleanup = async (puppet: any, token: string) => {
+  await puppet._payloadStore.stop()
+  try {
+    await fs.promises.rm(
+      path.join(os.homedir(), '.wechaty', 'wechaty-puppet-service', token),
+      { recursive: true, force: true },
+    )
+  } catch (_) { /* ignore */ }
+}
+
+/**
+ * A one-shot gate for a fake gRPC method. The method resolves `entered`
+ * as soon as it is invoked (by which point the caller's gen snapshot has
+ * already been taken, since the snapshot precedes the fetch call), then
+ * holds its callback until `release()` is called. This lets the test slot
+ * a dirty deterministically between the fetch start (gen snapshot) and
+ * the fetch resolution (write-back) -- no timers, no flakiness.
+ */
+const makeGate = () => {
+  let release: () => void = () => {}
+  let markEntered: () => void = () => {}
+  const gate    = new Promise<void>(resolve => { release = resolve })
+  const entered = new Promise<void>(resolve => { markEntered = resolve })
+  return { gate, entered, enter: () => markEntered(), release: () => release() }
+}
+
+test('contactRawPayload: a dirty mid-fetch skips the stale FlashStore write-back', async t => {
+  const { puppet, token } = await makePuppet()
+
+  const contactId = 'contact-race'
+  const response = new grpcPuppet.ContactPayloadResponse()
+  response.setId(contactId)
+  response.setName('stale-name-from-inflight-fetch')
+
+  const { gate, entered, enter, release } = makeGate()
+  puppet._grpcManager = {
+    client: {
+      contactPayload: (_req: any, cb: (err: any, r: any) => void) => {
+        enter()
+        void (async () => {
+          await gate
+          cb(null, response)
+        })()
+      },
+    },
+  }
+
+  // Start the fetch: it snapshots the gen, then blocks on the gate.
+  const fetchPromise = puppet.contactRawPayload(contactId)
+  // Deterministic: once the fake method is entered, the snapshot is taken.
+  await entered
+
+  // A dirty arrives while the fetch is in flight: bump gen + clear store,
+  // exactly as the EVENT_TYPE_DIRTY handler does.
+  puppet.cache.bumpGen(PUPPET.types.Dirty.Contact, contactId)
+  await puppet.fastDirty({ payloadType: PUPPET.types.Dirty.Contact, payloadId: contactId })
+
+  // Now let the stale fetch resolve into the write-back path.
+  release()
+  const returned = await fetchPromise
+
+  t.equal(returned.id, contactId, 'raw fetch still returns its payload to the caller')
+  const stored = await puppet._payloadStore.contact.get(contactId)
+  t.notOk(stored, 'stale in-flight fetch must NOT re-poison the FlashStore after the dirty')
+
+  await cleanup(puppet, token)
+})
+
+test('contactRawPayload: no dirty means the write-back proceeds as usual', async t => {
+  const { puppet, token } = await makePuppet()
+
+  const contactId = 'contact-happy'
+  const response = new grpcPuppet.ContactPayloadResponse()
+  response.setId(contactId)
+  response.setName('fresh-name')
+
+  puppet._grpcManager = {
+    client: {
+      contactPayload: (_req: any, cb: (err: any, r: any) => void) => cb(null, response),
+    },
+  }
+
+  const returned = await puppet.contactRawPayload(contactId)
+  t.equal(returned.id, contactId, 'raw fetch returns its payload')
+
+  const stored = await puppet._payloadStore.contact.get(contactId)
+  t.ok(stored, 'without a racing dirty the payload is written to the FlashStore')
+  t.equal(stored && stored.id, contactId, 'stored payload matches the fetched id')
+
+  await cleanup(puppet, token)
+})
+
+test('EVENT_TYPE_DIRTY bumps gen before awaiting fastDirty so pre-event snapshots are stale', async t => {
+  const { puppet, token } = await makePuppet()
+
+  const contactId = 'contact-bump'
+  // A getter that snapshotted just before the event arrived.
+  const snapshot = puppet.cache.snapshotGen(PUPPET.types.Dirty.Contact, contactId)
+
+  const dirtyJson = JSON.stringify({
+    payloadType: PUPPET.types.Dirty.Contact,
+    payloadId  : contactId,
+  })
+  await puppet.onGrpcStreamEvent({
+    getType   : () => grpcPuppet.EventType.EVENT_TYPE_DIRTY,
+    getPayload: () => dirtyJson,
+    getSeq    : () => 0,
+  })
+
+  t.notOk(
+    puppet.cache.isFreshWrite(PUPPET.types.Dirty.Contact, contactId, snapshot),
+    'a snapshot taken before the dirty event must be judged stale afterwards',
+  )
+
+  await cleanup(puppet, token)
+})
+
+test('EVENT_TYPE_DIRTY compound RoomMember bumps both the compound and the room-level gen', async t => {
+  const { puppet, token } = await makePuppet()
+
+  const roomId     = 'room-bump'
+  const memberId   = 'member-bump'
+  const compoundId = `${roomId}${PUPPET.STRING_SPLITTER}${memberId}`
+
+  const compoundSnap = puppet.cache.snapshotGen(PUPPET.types.Dirty.RoomMember, compoundId)
+  const roomSnap     = puppet.cache.snapshotGen(PUPPET.types.Dirty.RoomMember, roomId)
+
+  const dirtyJson = JSON.stringify({
+    payloadType: PUPPET.types.Dirty.RoomMember,
+    payloadId  : compoundId,
+  })
+  await puppet.onGrpcStreamEvent({
+    getType   : () => grpcPuppet.EventType.EVENT_TYPE_DIRTY,
+    getPayload: () => dirtyJson,
+    getSeq    : () => 0,
+  })
+
+  t.notOk(
+    puppet.cache.isFreshWrite(PUPPET.types.Dirty.RoomMember, compoundId, compoundSnap),
+    'the compound (roomId+SEP+memberId) key must be bumped',
+  )
+  t.notOk(
+    puppet.cache.isFreshWrite(PUPPET.types.Dirty.RoomMember, roomId, roomSnap),
+    'the bare room-level key must also be bumped so row-level write-backs are guarded',
+  )
+
+  await cleanup(puppet, token)
+})
+
+test('roomMemberRawPayload: a room-level dirty mid-fetch skips the row write-back', async t => {
+  const { puppet, token } = await makePuppet()
+
+  const roomId    = 'room-member-race'
+  const contactId = 'member-race'
+
+  const response = new grpcPuppet.RoomMemberPayloadResponse()
+  response.setId(contactId)
+  response.setName('stale-member-from-inflight-fetch')
+
+  const { gate, entered, enter, release } = makeGate()
+  puppet._grpcManager = {
+    client: {
+      roomMemberPayload: (_req: any, cb: (err: any, r: any) => void) => {
+        enter()
+        void (async () => {
+          await gate
+          cb(null, response)
+        })()
+      },
+    },
+  }
+
+  // Start the fetch: it snapshots the room-level gen before reading the
+  // row, then blocks on the gate.
+  const fetchPromise = puppet.roomMemberRawPayload(roomId, contactId)
+  await entered
+
+  // A bare-roomId dirty lands mid-fetch: the whole member set is stale.
+  puppet.cache.bumpGen(PUPPET.types.Dirty.RoomMember, roomId)
+  await puppet.fastDirty({ payloadType: PUPPET.types.Dirty.RoomMember, payloadId: roomId })
+
+  release()
+  const returned = await fetchPromise
+
+  t.equal(returned.id, contactId, 'raw fetch still returns its member payload to the caller')
+  const stored = await puppet._payloadStore.roomMember.get(roomId)
+  t.notOk(stored, 'stale in-flight member fetch must NOT re-create the row after the dirty')
+
+  await cleanup(puppet, token)
+})


### PR DESCRIPTION
## 问题

「必须 dirty 两次才能读到新值」回归的 FlashStore 层：`EVENT_TYPE_DIRTY` 到达后 `fastDirty` 删掉 `_payloadStore` 行，但 dirty 之前启动的 gRPC raw fetch 随后返回，把旧 payload 原样写回——缓存刚清干净又被毒回，LRU miss 后照样从 FlashStore 命中旧值。

上游 LRU 层修复见 juzibot/wechaty-puppet#107；本仓的 FlashStore 是独立缓存层，必须自带防护。

## 修复

- `EVENT_TYPE_DIRTY` 分支在 `await fastDirty` **之前** `bumpGen`，罩住整个 fastDirty 窗口；RoomMember 复合 id 额外 bump 房间级 key（行级写回以 roomId 为 gen key）
- 7 处 `_payloadStore` 写回统一加防护（fetch 前 `snapshotGen`、写回前 `isFreshWrite`、陈旧则跳过 set 并记 silly 日志，返回值不变）：contact / batchContact / room / batchRoom / roomMember / batchRoomMember / tag / tagGroup
- roomMember 是行级 read-modify-write，snapshot 在读缓存行之前取，房间级 dirty 落在窗口任意位置都会跳过合并写回
- 与上游 onDirty 的双 bump 无害（gen 只做等值比较）

## 验证

- 新增 `tests/dirty-gen-guard.spec.ts` 5 个用例（contact 竞态、happy path、提前 bump、复合 RoomMember 双 key、roomMember 行级竞态），信号量驱动无 timer 无 flake
- `npm test`（lint + tap 26 spec files）全绿

## 发布

含版本 commit：升 `@juzi/wechaty-puppet` 至 ^1.0.149、自身 bump 1.0.125。**需等 wechaty-puppet 1.0.149 发布后再合并**（发版顺序 puppet → service）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)